### PR TITLE
Convert parser node methods into a single class

### DIFF
--- a/app/parser/Context.test.tsx
+++ b/app/parser/Context.test.tsx
@@ -6,8 +6,6 @@ declare var global: any;
 var cheerio: any = require('cheerio');
 var window: any = cheerio.load('<div>');
 
-const EMPTY_CTX = {scope:{}, views:{}};
-
 describe('Context', () => {
   describe('evaluateOp', () => {
   	it('returns null on invalid eval', () => {

--- a/app/parser/Context.test.tsx
+++ b/app/parser/Context.test.tsx
@@ -1,4 +1,5 @@
 import {evaluateOp, evaluateContentOps} from './Context'
+import {defaultQuestContext} from '../reducers/QuestTypes'
 
 declare var global: any;
 
@@ -10,27 +11,27 @@ const EMPTY_CTX = {scope:{}, views:{}};
 describe('Context', () => {
   describe('evaluateOp', () => {
   	it('returns null on invalid eval', () => {
-  		expect(evaluateOp('asdf', {...EMPTY_CTX})).toEqual(null);
+  		expect(evaluateOp('asdf', defaultQuestContext())).toEqual(null);
   	});
   	it('returns value and updates context', () => {
-  		const ctx = {...EMPTY_CTX, scope: {b: '1'}};
+  		const ctx = {...defaultQuestContext(), scope: {b: '1'}};
   		expect(evaluateOp('a=b+1;a', ctx)).toEqual(2);
   		expect(ctx.scope).toEqual({a: 2, b: '1'});
   	});
   	it('does not return if last operation assigns a value', () => {
-			expect(evaluateOp('a=1', {...EMPTY_CTX})).toEqual(null);
+			expect(evaluateOp('a=1', defaultQuestContext())).toEqual(null);
   	});
   });
 
   describe('evaluateContentOps', () => {
   	it('persists state', () => {
-  		const ctx = {...EMPTY_CTX};
+  		const ctx = defaultQuestContext();
   		expect(evaluateContentOps('{{text="TEST"}}', ctx)).toEqual('');
   		expect(evaluateContentOps('{{text}}', ctx)).toEqual('TEST');
     });
 
   	it('handles multiple ops in one string', () => {
-  		const ctx = {...EMPTY_CTX};
+  		const ctx = defaultQuestContext();
   		expect(evaluateContentOps('{{text="TEST"}}\n{{text}}', ctx)).toEqual('\nTEST');
   	});
   });

--- a/app/parser/Context.test.tsx
+++ b/app/parser/Context.test.tsx
@@ -12,7 +12,7 @@ describe('Context', () => {
   		expect(evaluateOp('asdf', defaultQuestContext())).toEqual(null);
   	});
   	it('returns value and updates context', () => {
-  		const ctx = {...defaultQuestContext(), scope: {b: '1'}};
+  		const ctx = {...defaultQuestContext(), scope: {b: '1'} as any};
   		expect(evaluateOp('a=b+1;a', ctx)).toEqual(2);
   		expect(ctx.scope).toEqual({a: 2, b: '1'});
   	});

--- a/app/parser/Context.test.tsx
+++ b/app/parser/Context.test.tsx
@@ -1,0 +1,37 @@
+import {evaluateOp, evaluateContentOps} from './Context'
+
+declare var global: any;
+
+var cheerio: any = require('cheerio');
+var window: any = cheerio.load('<div>');
+
+const EMPTY_CTX = {scope:{}, views:{}};
+
+describe('Context', () => {
+  describe('evaluateOp', () => {
+  	it('returns null on invalid eval', () => {
+  		expect(evaluateOp('asdf', {...EMPTY_CTX})).toEqual(null);
+  	});
+  	it('returns value and updates context', () => {
+  		const ctx = {...EMPTY_CTX, scope: {b: '1'}};
+  		expect(evaluateOp('a=b+1;a', ctx)).toEqual(2);
+  		expect(ctx.scope).toEqual({a: 2, b: '1'});
+  	});
+  	it('does not return if last operation assigns a value', () => {
+			expect(evaluateOp('a=1', {...EMPTY_CTX})).toEqual(null);
+  	});
+  });
+
+  describe('evaluateContentOps', () => {
+  	it('persists state', () => {
+  		const ctx = {...EMPTY_CTX};
+  		expect(evaluateContentOps('{{text="TEST"}}', ctx)).toEqual('');
+  		expect(evaluateContentOps('{{text}}', ctx)).toEqual('TEST');
+    });
+
+  	it('handles multiple ops in one string', () => {
+  		const ctx = {...EMPTY_CTX};
+  		expect(evaluateContentOps('{{text="TEST"}}\n{{text}}', ctx)).toEqual('\nTEST');
+  	});
+  });
+});

--- a/app/parser/Context.tsx
+++ b/app/parser/Context.tsx
@@ -34,7 +34,9 @@ export function evaluateContentOps(content: string, ctx: QuestContext): string {
   return result;
 }
 
-// If it's an operation, run it with our context.
+// Attempts to evaluate op using ctx.
+// If the evaluation is successful, the context is modified as determined by the op.
+// If the last operation does not assign a value, the result is returned.
 export function evaluateOp(op: string, ctx: QuestContext): any {
   const parsed = Math.parse(HtmlDecode(op));
   let evalResult;
@@ -45,7 +47,7 @@ export function evaluateOp(op: string, ctx: QuestContext): any {
     return null;
   }
 
-  // Only add the result to content IF it doesn't assign a value as its last action.
+  // Only return the result IF it doesn't assign a value as its last action.
   if (!lastExpressionAssignsValue(parsed)) {
 
     // If ResultSet, then unwrap it and get the last value.
@@ -68,6 +70,7 @@ export function evaluateOp(op: string, ctx: QuestContext): any {
     }
     return evalResult;
   }
+  return null;
 }
 
 function lastExpressionAssignsValue(parsed: any): boolean {
@@ -77,7 +80,7 @@ function lastExpressionAssignsValue(parsed: any): boolean {
   return (parsed.type === 'AssignmentNode' || parsed.type === 'FunctionAssignmentNode');
 }
 
-export function parseOpString(str: string): string {
+function parseOpString(str: string): string {
   const op = str.match(/{{([\s\S]+?)}}/);
   if (!op) {
     return null;

--- a/app/parser/Handlers.test.tsx
+++ b/app/parser/Handlers.test.tsx
@@ -118,6 +118,12 @@ describe('Handlers', () => {
       expect(context.scope._.viewCount('foo')).toEqual(2);
       expect(context.scope._.viewCount('bar')).toEqual(1);
     });
+
+    it('respects in-card conditionals when computing Next vs End button', () => {
+      var result = loadRoleplayNode(cheerio.load('<roleplay>{{a=true}}</roleplay><trigger if="a">end</trigger><roleplay>test</roleplay>')('roleplay'), defaultQuestContext());
+      expect (result.content[0].type).toEqual("end");
+
+    });
   });
 
   describe('combat', () => {

--- a/app/parser/Handlers.test.tsx
+++ b/app/parser/Handlers.test.tsx
@@ -120,9 +120,9 @@ describe('Handlers', () => {
     });
 
     it('respects in-card conditionals when computing Next vs End button', () => {
-      var result = loadRoleplayNode(cheerio.load('<roleplay>{{a=true}}</roleplay><trigger if="a">end</trigger><roleplay>test</roleplay>')('roleplay'), defaultQuestContext());
-      expect (result.content[0].type).toEqual("end");
-
+      let quest = cheerio.load('<quest><roleplay><p>{{a=true}}</p></roleplay><trigger if="a">end</trigger><roleplay>test</roleplay></quest>')('quest');
+      var result = loadRoleplayNode(quest.children().eq(0), defaultQuestContext());
+      expect (result.choices).toEqual([{ text: 'End', idx: 0}]);
     });
   });
 

--- a/app/parser/Handlers.tsx
+++ b/app/parser/Handlers.tsx
@@ -79,7 +79,7 @@ export function handleChoice(parent: XMLElement, choice: number, ctx: QuestConte
 
   // Scan the parent node to find the choice with the right number
   let choiceIdx = -1;
-  let child = pnode.loopChildren((tag, child, idx) => {
+  let child = pnode.loopChildren((tag, child) => {
     if (tag !== 'choice') {
       return;
     }

--- a/app/parser/Node.test.tsx
+++ b/app/parser/Node.test.tsx
@@ -5,8 +5,6 @@ declare var global: any;
 var cheerio: any = require('cheerio');
 var window: any = cheerio.load('<div>');
 
-const EMPTY_CTX = {scope:{}, views:{}};
-
 describe('Node', () => {
   describe('getNext', () => {
   	it('returns next element if enabled', () => {

--- a/app/parser/Node.test.tsx
+++ b/app/parser/Node.test.tsx
@@ -1,0 +1,26 @@
+import {evaluateOp, evaluateContentOps} from './Context'
+
+declare var global: any;
+
+var cheerio: any = require('cheerio');
+var window: any = cheerio.load('<div>');
+
+const EMPTY_CTX = {scope:{}, views:{}};
+
+describe('Node', () => {
+  describe('getNext', () => {
+  	it('returns next element if enabled');
+    it('skips disabled elements');
+    it('returns null if no next element');
+  });
+
+  describe('gotoId', () => {
+  	it('goes to ID');
+    it('returns null if ID does not exist');
+  });
+
+  describe('loopChildren', () => {
+    it('loops only enabled children');
+    it('stops early when a value is returned');
+  });
+});

--- a/app/parser/Node.test.tsx
+++ b/app/parser/Node.test.tsx
@@ -1,5 +1,5 @@
-import {evaluateOp, evaluateContentOps} from './Context'
-
+import {ParserNode} from './Node'
+import {defaultQuestContext} from '../reducers/QuestTypes'
 declare var global: any;
 
 var cheerio: any = require('cheerio');
@@ -9,18 +9,62 @@ const EMPTY_CTX = {scope:{}, views:{}};
 
 describe('Node', () => {
   describe('getNext', () => {
-  	it('returns next element if enabled');
-    it('skips disabled elements');
-    it('returns null if no next element');
+  	it('returns next element if enabled', () => {
+      const quest = cheerio.load('<quest><roleplay></roleplay><roleplay if="asdf">expected</roleplay><roleplay>wrong</roleplay></quest>')('quest');
+      const pnode = new ParserNode(quest.children().eq(0), {...defaultQuestContext(), scope: {asdf: true}});
+      expect(pnode.getNext().elem.text()).toEqual('expected');
+    });
+    it('skips disabled elements', () => {
+      const quest = cheerio.load('<quest><roleplay></roleplay><roleplay if="asdf">wrong</roleplay><roleplay>expected</roleplay></quest>')('quest');
+      const pnode = new ParserNode(quest.children().eq(0), defaultQuestContext());
+      expect(pnode.getNext().elem.text()).toEqual('expected');
+    });
+    it('returns null if no next element', () => {
+      const pnode = new ParserNode(cheerio.load('<roleplay></roleplay>')('roleplay'), defaultQuestContext());
+      expect(pnode.getNext()).toEqual(null);
+    });
   });
 
   describe('gotoId', () => {
-  	it('goes to ID');
-    it('returns null if ID does not exist');
+  	it('goes to ID', () => {
+      const quest = cheerio.load('<quest><roleplay></roleplay><roleplay>wrong</roleplay><roleplay id="test">expected</roleplay></quest>')('quest');
+      const pnode = new ParserNode(quest.children().eq(0), defaultQuestContext());
+      expect(pnode.gotoId('test').elem.text()).toEqual('expected');
+    });
+    it('returns null if ID does not exist', () => {
+      const quest = cheerio.load('<quest><roleplay>wrong</roleplay></quest>')('quest');
+      const pnode = new ParserNode(quest.children().eq(0), defaultQuestContext());
+      expect(pnode.gotoId('test')).toEqual(null);
+    });
+    it('returns null when no <quest> tag', () => {
+      const pnode = new ParserNode(cheerio.load('<roleplay><choice><roleplay id="test">wrong</roleplay></choice></roleplay>')('#test').eq(0), defaultQuestContext());
+      expect(pnode.gotoId('test')).toEqual(null);
+    });
+    it('safely handles multiple identical ids', () => {
+      const quest = cheerio.load('<quest><roleplay></roleplay><roleplay id="test">expected</roleplay><roleplay id="test">expected</roleplay></quest>')('quest');
+      const pnode = new ParserNode(quest.children().eq(0), defaultQuestContext());
+      expect(pnode.gotoId('test').elem.text()).toEqual('expected');
+    });
   });
 
   describe('loopChildren', () => {
-    it('loops only enabled children');
-    it('stops early when a value is returned');
+    it('loops only enabled children', () => {
+      const pnode = new ParserNode(cheerio.load('<roleplay><p>1</p><b>2</b><p if="a">3</p><i>4</i></roleplay>')('roleplay'), defaultQuestContext());
+      let agg: any[] = [];
+      let result = pnode.loopChildren((tag, c) => {
+        agg.push(tag);
+      });
+      expect(result).toEqual(undefined);
+      expect(agg).toEqual(['p', 'b', 'i']);
+    });
+    it('stops early when a value is returned', () => {
+      const pnode = new ParserNode(cheerio.load('<roleplay><p>1</p><b>2</b><p if="a">3</p><i>4</i></roleplay>')('roleplay'), defaultQuestContext());
+      let result = pnode.loopChildren((tag, c) => {
+        if (c.text() === '2') {
+          return tag;
+        }
+      });
+      expect(result).toEqual('b');
+    });
   });
 });

--- a/app/parser/Node.tsx
+++ b/app/parser/Node.tsx
@@ -50,11 +50,14 @@ export class ParserNode {
 
   // Loop through all enabled children. If a call to cb() returns a value
   // other than undefined, break the loop early and return the value.
-  loopChildren(cb: (enabled: boolean, tag: string, c: XMLElement, i: number)=>any): any {
+  loopChildren(cb: (tag: string, c: XMLElement, i: number)=>any): any {
     for (let i = 0; i < this.elem.children().length; i++) {
       let c = this.elem.children().eq(i);
+      if (!this.isElemEnabled(c)) {
+        continue;
+      }
       let tag = this.elem.children().get(i).tagName.toLowerCase();
-      let v = cb(this.isElemEnabled(c), tag, c, i);
+      let v = cb(tag, c, i);
       if (v !== undefined) {
         return v;
       }

--- a/app/parser/Node.tsx
+++ b/app/parser/Node.tsx
@@ -4,67 +4,92 @@ import {QuestContext} from '../reducers/QuestTypes'
 
 const Clone = require('clone');
 const Math = require('mathjs') as any;
-// TODO(scott): Turn this into a class that wraps XMLElement
 
-export function findNextNode(node: XMLElement, ctx: QuestContext): XMLElement {
-  while (true) {
-    if (node.length === 0) {
+export class ParserNode {
+  public elem: XMLElement;
+  private ctx: QuestContext;
+
+  constructor(elem: XMLElement, ctx: QuestContext) {
+    this.elem = elem;
+    this.ctx = ctx;
+  }
+
+  getNext(): ParserNode {
+    let elem = this.elem;
+    while (true) {
+      if (elem.length === 0) {
+        return null;
+      }
+
+      const sibling = elem.next();
+
+      // Skip control elements
+      if (sibling !== null && sibling.length > 0 
+          && !this.isElemControl(sibling) 
+          && this.isElemEnabled(sibling)) {
+        return new ParserNode(sibling, this.ctx);
+      }
+
+      // Continue searching neighbors if we have neighbors, otherwise
+      // search in the parent elem.
+      if (sibling !== null && sibling.length > 0) {
+        elem = sibling;
+      } else {
+        elem = elem.parent();
+      }
+    }
+  }
+
+  gotoId(id: string): ParserNode {
+    const dest = this.getRootElem().find('#'+id).eq(0);
+    if (!dest) {
       return null;
     }
+    return new ParserNode(dest, this.ctx);
+  }
 
-    const sibling = node.next();
+  // Loop through all enabled children. If a call to cb() returns a value
+  // other than undefined, break the loop early and return the value.
+  loopChildren(cb: (enabled: boolean, tag: string, c: XMLElement, i: number)=>any): any {
+    for (let i = 0; i < this.elem.children().length; i++) {
+      let c = this.elem.children().eq(i);
+      let tag = this.elem.children().get(i).tagName.toLowerCase();
+      let v = cb(this.isElemEnabled(c), tag, c, i);
+      if (v !== undefined) {
+        return v;
+      }
+    }
+  }
 
-    // Skip control elements
-    if (sibling !== null && sibling.length > 0 && !isControlNode(sibling) && isEnabled(sibling, ctx)) {
-      return sibling;
+  private getRootElem(): XMLElement {
+    let elem = this.elem;
+    while (elem !== null && elem.get(0).tagName.toLowerCase() !== 'quest') {
+      elem = elem.parent();
+    }
+    return elem;
+  }
+
+  private isElemControl(elem: XMLElement): boolean {
+    const tagName = elem.get(0).tagName.toLowerCase();
+    return tagName === 'choice' || tagName === 'event' || (elem.attr('on') != null);
+  }
+
+  private isElemEnabled(elem: XMLElement): boolean {
+    const ifExpr = elem.attr('if');
+    if (!ifExpr) {
+      return true;
     }
 
-    // Continue searching neighbors if we have neighbors, otherwise
-    // search in the parent node.
-    if (sibling !== null && sibling.length > 0) {
-      node = sibling;
-    } else {
-      node = node.parent();
-    }
-  }
-}
+    try {
+      // Operate on copied scope - checking for enablement should never change the current context.
+      // TODO(scott): Make this use Context.tsx (evaluateOp?)
+      const visible = Math.eval(ifExpr, Clone(this.ctx.scope));
 
-export function findRootNode(node: XMLElement): XMLElement {
-  while (node !== null && node.get(0).tagName.toLowerCase() !== 'quest') {
-    node = node.parent();
-  }
-  return node;
-}
-
-export function isControlNode(node: XMLElement): boolean {
-  const tagName = node.get(0).tagName.toLowerCase();
-  return tagName === 'choice' || tagName === 'event' || (node.attr('on') != null);
-}
-
-export function isEnabled(node: XMLElement, ctx: QuestContext): boolean {
-  const ifExpr = node.attr('if');
-  if (!ifExpr) {
-    return true;
-  }
-
-  try {
-    // Operate on copied scope - checking for enablement should never change the current context.
-    // TODO(scott): Make this use Context.tsx (evaluateOp?)
-    const visible = Math.eval(ifExpr, Clone(ctx.scope));
-
-    // We check for truthiness here, so nonzero numbers are true, etc.
-    return Boolean(visible);
-  } catch (e) {
-    // If we fail to evaluate (e.g. symbol not defined), treat the node as not visible.
-    return false;
-  }
-}
-
-export function loopChildren(node: XMLElement, cb: (tag: string, c: XMLElement)=>any) {
-  for (let i = 0; i < node.children().length; i++) {
-    let v = cb(node.children().get(i).tagName.toLowerCase(), node.children().eq(i));
-    if (v !== undefined) {
-      return v;
+      // We check for truthiness here, so nonzero numbers are true, etc.
+      return Boolean(visible);
+    } catch (e) {
+      // If we fail to evaluate (e.g. symbol not defined), treat the elem as not visible.
+      return false;
     }
   }
 }

--- a/app/parser/Node.tsx
+++ b/app/parser/Node.tsx
@@ -41,23 +41,23 @@ export class ParserNode {
   }
 
   gotoId(id: string): ParserNode {
-    const dest = this.getRootElem().find('#'+id).eq(0);
-    if (!dest) {
+    const search = this.getRootElem().find('#'+id);
+    if (search.length === 0) {
       return null;
     }
-    return new ParserNode(dest, this.ctx);
+    return new ParserNode(search.eq(0), this.ctx);
   }
 
   // Loop through all enabled children. If a call to cb() returns a value
   // other than undefined, break the loop early and return the value.
-  loopChildren(cb: (tag: string, c: XMLElement, i: number)=>any): any {
+  loopChildren(cb: (tag: string, c: XMLElement)=>any): any {
     for (let i = 0; i < this.elem.children().length; i++) {
       let c = this.elem.children().eq(i);
       if (!this.isElemEnabled(c)) {
         continue;
       }
       let tag = this.elem.children().get(i).tagName.toLowerCase();
-      let v = cb(tag, c, i);
+      let v = cb(tag, c);
       if (v !== undefined) {
         return v;
       }
@@ -66,7 +66,7 @@ export class ParserNode {
 
   private getRootElem(): XMLElement {
     let elem = this.elem;
-    while (elem !== null && elem.get(0).tagName.toLowerCase() !== 'quest') {
+    while (elem && elem.get(0) && elem.get(0).tagName.toLowerCase() !== 'quest') {
       elem = elem.parent();
     }
     return elem;

--- a/app/parser/Validation.tsx
+++ b/app/parser/Validation.tsx
@@ -1,6 +1,8 @@
 import * as React from 'react'
 import {XMLElement} from '../reducers/StateTypes'
 
+// TODO(https://github.com/ExpeditionRPG/expedition-app/issues/291): Actually use this
+
 export function isEmptyObject(obj: Object): boolean {
   return Object.keys(obj).length === 0 && JSON.stringify(obj) === JSON.stringify({});
 }


### PR DESCRIPTION
#288

`ParserNode` will soon be the kernel of state that's passed about by handlers etc. Eventually choice and event logic will end up in there as well, with construction of `CombatResult`, `RoleplayResult` etc. still being done in `Handlers.tsx`

Also added a todo for using the validation code in the app.