### PR TITLE
Cleanup parser handler functions

### DIFF
--- a/app/actions/quest.tsx
+++ b/app/actions/quest.tsx
@@ -11,7 +11,7 @@ import {
 } from './ActionTypes'
 import {SettingsType, XMLElement} from '../reducers/StateTypes'
 import {toCard, toPrevious} from './card'
-import {loadTriggerNode, loadCombatNode, loadRoleplayNode, handleChoice, handleEvent, RoleplayResult, CombatResult} from '../parser/Handlers'
+import {loadTriggerNode, loadCombatNode, loadRoleplayNode, handleAction, RoleplayResult, CombatResult} from '../parser/Handlers'
 import {QuestDetails, QuestContext} from '../reducers/QuestTypes'
 
 
@@ -42,7 +42,7 @@ export function initCombat(node: XMLElement, settings: SettingsType, result: Com
 
 export function choice(settings: SettingsType, node: XMLElement, index: number, ctx: QuestContext) {
   return (dispatch: Redux.Dispatch<any>): any => {
-    var nextNode: XMLElement = handleChoice(node, index, ctx);
+    var nextNode: XMLElement = handleAction(node, index, ctx);
     loadNode(settings, dispatch, nextNode, ctx);
   }
 }
@@ -87,7 +87,7 @@ export function loadNode(settings: SettingsType, dispatch: Redux.Dispatch<any>, 
 
 export function event(node: XMLElement, evt: string, ctx: QuestContext) {
   return (dispatch: Redux.Dispatch<any>): any => {
-    var nextNode: XMLElement = handleEvent(node, evt, ctx);
+    var nextNode: XMLElement = handleAction(node, evt, ctx);
     loadNode(null, dispatch, nextNode, ctx);
   }
 }

--- a/app/parser/Handlers.test.tsx
+++ b/app/parser/Handlers.test.tsx
@@ -1,5 +1,5 @@
 import {mount} from 'enzyme'
-import {loadRoleplayNode, loadCombatNode, loadTriggerNode, handleAction} from './Handlers'
+import {loadRoleplayNode, loadCombatNode, loadTriggerNode, handleAction, getEventParameters} from './Handlers'
 import {defaultQuestContext} from '../reducers/QuestTypes'
 
 declare var global: any;
@@ -203,6 +203,20 @@ describe('Handlers', () => {
     it('triggers end', () => {
       var result = loadTriggerNode(cheerio.load('<trigger>end</trigger>')('trigger'));
       expect(result.name).toEqual('end');
+    });
+  });
+
+  describe('getEventParameters', () => {
+    it('gets parameters', () => {
+      var node = cheerio.load('<combat><event on="win" heal="5" loot="false" xp="false"><roleplay></roleplay></event></combat>')('combat');
+      expect(getEventParameters(node, 'win', defaultQuestContext())).toEqual({
+        heal: 5, loot: false, xp: false
+      });
+    });
+
+    it('safely handles event with no params', () => {
+      var node = cheerio.load('<combat><event on="win"><roleplay></roleplay></event></combat>')('combat');
+      expect(getEventParameters(node, 'win', defaultQuestContext())).toEqual({});
     });
   });
 

--- a/app/parser/Handlers.tsx
+++ b/app/parser/Handlers.tsx
@@ -57,14 +57,19 @@ export function handleAction(parent: XMLElement, action: number|string, ctx: Que
     return null;
   }
 
-  // Immediately act on any gotos
-  while (pnode.elem.get(0).tagName === 'trigger') {
+  // Immediately act on any gotos (with a max depth)
+  let i = 0;
+  for (; i < 100 && pnode.elem.get(0).tagName === 'trigger'; i++) {
     let id = getTriggerId(pnode.elem);
     if (id) {
       pnode = pnode.gotoId(id);
     } else {
       break;
     }
+  }
+
+  if (i >= 100) {
+    throw new Error('Trigger follow depth exceeded');
   }
   return (pnode) ? pnode.elem : null;
 }

--- a/app/parser/Node.test.tsx
+++ b/app/parser/Node.test.tsx
@@ -7,7 +7,7 @@ var window: any = cheerio.load('<div>');
 
 describe('Node', () => {
   describe('getNext', () => {
-  	it('returns next element if enabled', () => {
+    it('returns next node if enabled', () => {
       const quest = cheerio.load('<quest><roleplay></roleplay><roleplay if="asdf">expected</roleplay><roleplay>wrong</roleplay></quest>')('quest');
       const pnode = new ParserNode(quest.children().eq(0), {...defaultQuestContext(), scope: {asdf: true}});
       expect(pnode.getNext().elem.text()).toEqual('expected');
@@ -20,6 +20,21 @@ describe('Node', () => {
     it('returns null if no next element', () => {
       const pnode = new ParserNode(cheerio.load('<roleplay></roleplay>')('roleplay'), defaultQuestContext());
       expect(pnode.getNext()).toEqual(null);
+    });
+    it('returns next node if choice=0 and no choice', () => {
+      const quest = cheerio.load('<quest><roleplay></roleplay><roleplay>expected</roleplay></quest>')('quest');
+      const pnode = new ParserNode(quest.children().eq(0), defaultQuestContext());
+      expect(pnode.getNext(0).elem.text()).toEqual('expected');
+    });
+    it('returns node given by choice index', () => {
+      const quest = cheerio.load('<quest><roleplay><choice></choice><choice if="asdf"></choice><choice><roleplay>expected</roleplay><roleplay>wrong</roleplay></choice></roleplay></quest>')('quest');
+      const pnode = new ParserNode(quest.children().eq(0), defaultQuestContext());
+      expect(pnode.getNext(1).elem.text()).toEqual('expected');
+    });
+    it('returns node given by event name', () => {
+      const quest = cheerio.load('<quest><roleplay><event></event><choice></choice><event on="test"><roleplay>expected</roleplay><roleplay>wrong</roleplay></event></roleplay></quest>')('quest');
+      const pnode = new ParserNode(quest.children().eq(0), defaultQuestContext());
+      expect(pnode.getNext('test').elem.text()).toEqual('expected');
     });
   });
 


### PR DESCRIPTION
- `handleChoice` and `handleEvent` are now `handleAction`
- `getEventParameters` has been completely refactored to use the new Node code. Unit tests were added.
- commented tests in `Handlers.tsx` are now removed (they're no longer useful)
- `handleAction` can now follow multiple consecutive trigger commands without any additional handling downstream.

Once this is in, we can unify the `loadXYZNode` code into a single loader method and have all `XYZResult` interfaces share common attributes.