### PR TITLE
Push op rendering into ParserNode

### DIFF
--- a/app/parser/Context.test.tsx
+++ b/app/parser/Context.test.tsx
@@ -8,29 +8,29 @@ var window: any = cheerio.load('<div>');
 
 describe('Context', () => {
   describe('evaluateOp', () => {
-  	it('returns null on invalid eval', () => {
-  		expect(evaluateOp('asdf', defaultQuestContext())).toEqual(null);
-  	});
-  	it('returns value and updates context', () => {
-  		const ctx = {...defaultQuestContext(), scope: {b: '1'} as any};
-  		expect(evaluateOp('a=b+1;a', ctx)).toEqual(2);
-  		expect(ctx.scope).toEqual({a: 2, b: '1'});
-  	});
-  	it('does not return if last operation assigns a value', () => {
-			expect(evaluateOp('a=1', defaultQuestContext())).toEqual(null);
-  	});
+    it('returns null on invalid eval', () => {
+      expect(evaluateOp('asdf', defaultQuestContext())).toEqual(null);
+    });
+    it('returns value and updates context', () => {
+      const ctx = {...defaultQuestContext(), scope: {b: '1'} as any};
+      expect(evaluateOp('a=b+1;a', ctx)).toEqual(2);
+      expect(ctx.scope).toEqual({a: 2, b: '1'});
+    });
+    it('does not return if last operation assigns a value', () => {
+      expect(evaluateOp('a=1', defaultQuestContext())).toEqual(null);
+    });
   });
 
   describe('evaluateContentOps', () => {
-  	it('persists state', () => {
-  		const ctx = defaultQuestContext();
-  		expect(evaluateContentOps('{{text="TEST"}}', ctx)).toEqual('');
-  		expect(evaluateContentOps('{{text}}', ctx)).toEqual('TEST');
+    it('persists state', () => {
+      const ctx = defaultQuestContext();
+      expect(evaluateContentOps('{{text="TEST"}}', ctx)).toEqual('');
+      expect(evaluateContentOps('{{text}}', ctx)).toEqual('TEST');
     });
 
-  	it('handles multiple ops in one string', () => {
-  		const ctx = defaultQuestContext();
-  		expect(evaluateContentOps('{{text="TEST"}}\n{{text}}', ctx)).toEqual('\nTEST');
-  	});
+    it('handles multiple ops in one string', () => {
+      const ctx = defaultQuestContext();
+      expect(evaluateContentOps('{{text="TEST"}}\n{{text}}', ctx)).toEqual('TEST');
+    });
   });
 });

--- a/app/parser/Handlers.test.tsx
+++ b/app/parser/Handlers.test.tsx
@@ -8,7 +8,6 @@ var cheerio: any = require('cheerio');
 var window: any = cheerio.load('<div>');
 
 describe('Handlers', () => {
-
   describe('roleplay', () => {
     it('parses ops in body', () => {
       // Lines with nothing but variable assignment are hidden
@@ -182,8 +181,7 @@ describe('Handlers', () => {
 
       // Not defined
       let context = defaultQuestContext();
-      var result = loadCombatNode(node, context);
-      expect(result.enemies).toEqual([{name: '{{a}}', tier: 1}]);
+      expect(() => {loadCombatNode(node, context)}).toThrow();
 
       // String
       context = defaultQuestContext();
@@ -229,7 +227,9 @@ describe('Handlers', () => {
 
     it('uses enabled triggers', () => {
       var quest = cheerio.load('<quest><roleplay><choice><trigger if="a">goto 5</trigger><trigger>end</trigger><roleplay id="5">expected</roleplay><roleplay>wrong</roleplay></choice></roleplay></quest>')('quest');
-      var result = handleAction(quest.children().eq(0), 0, {...defaultQuestContext(), scope: {a: true}});
+      let ctx = defaultQuestContext();
+      ctx.scope.a = true;
+      var result = handleAction(quest.children().eq(0), 0, ctx);
       expect(result.text()).toEqual('expected');
     });
 

--- a/app/parser/Handlers.test.tsx
+++ b/app/parser/Handlers.test.tsx
@@ -233,6 +233,16 @@ describe('Handlers', () => {
       expect(result.text()).toEqual('expected');
     });
 
+    /*
+    TODO
+    it('uses programmatic triggers', () => {
+      var quest = cheerio.load('<quest><roleplay><p>{{dest=5}}</p><choice><trigger>goto {{dest}}</trigger><trigger>end</trigger><roleplay id="5">expected</roleplay><roleplay>wrong</roleplay></choice></roleplay></quest>')('quest');
+      let ctx = defaultQuestContext();
+      var result = handleAction(quest.children().eq(0), 0, ctx);
+      expect(result.text()).toEqual('expected');
+    })
+    */
+
     it('can handle multiple gotos', () => {
       var quest = cheerio.load('<quest><roleplay><choice><trigger>goto 1</trigger><trigger id="1">goto 2</trigger><trigger id="2">end</trigger><roleplay>wrong</roleplay></choice></roleplay></quest>')('quest');
       var result = handleAction(quest.children().eq(0), 0, defaultQuestContext());

--- a/app/parser/Node.test.tsx
+++ b/app/parser/Node.test.tsx
@@ -9,7 +9,9 @@ describe('Node', () => {
   describe('getNext', () => {
     it('returns next node if enabled', () => {
       const quest = cheerio.load('<quest><roleplay></roleplay><roleplay if="asdf">expected</roleplay><roleplay>wrong</roleplay></quest>')('quest');
-      const pnode = new ParserNode(quest.children().eq(0), {...defaultQuestContext(), scope: {asdf: true}});
+      let ctx = defaultQuestContext();
+      ctx.scope.asdf = true;
+      const pnode = new ParserNode(quest.children().eq(0), ctx);
       expect(pnode.getNext().elem.text()).toEqual('expected');
     });
     it('skips disabled elements', () => {
@@ -61,6 +63,11 @@ describe('Node', () => {
   });
 
   describe('loopChildren', () => {
+    it('handles empty case', () => {
+      const pnode = new ParserNode(cheerio.load('<roleplay></roleplay>')('roleplay'), defaultQuestContext());
+      let sawChild = pnode.loopChildren((tag, c) => { return true; }) || false;
+      expect(sawChild).toEqual(false);
+    })
     it('loops only enabled children', () => {
       const pnode = new ParserNode(cheerio.load('<roleplay><p>1</p><b>2</b><p if="a">3</p><i>4</i></roleplay>')('roleplay'), defaultQuestContext());
       let agg: any[] = [];

--- a/app/parser/Node.tsx
+++ b/app/parser/Node.tsx
@@ -65,6 +65,9 @@ export class ParserNode {
   private renderChildren() {
     this.renderedChildren = [];
     for (let i = 0; i < this.elem.children().length; i++) {
+      // TODO(scott): Parsing of text nodes using .contents()
+      // Should handle programmatic gotos, for instance.
+
       let child = this.elem.children().eq(i);
       if (!this.isElemEnabled(child)) {
         continue;

--- a/app/parser/Node.tsx
+++ b/app/parser/Node.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react'
 import {XMLElement} from '../reducers/StateTypes'
 import {QuestContext} from '../reducers/QuestTypes'
+import {updateContext, evaluateContentOps} from './Context'
 
 const Clone = require('clone');
 const Math = require('mathjs') as any;
@@ -12,11 +13,13 @@ function isNumeric(n: any): boolean {
 
 export class ParserNode {
   public elem: XMLElement;
-  private ctx: QuestContext;
+  public ctx: QuestContext;
+  private renderedChildren: {rendered: XMLElement, original: XMLElement}[];
 
   constructor(elem: XMLElement, ctx: QuestContext) {
     this.elem = elem;
-    this.ctx = ctx;
+    this.ctx = updateContext(elem, ctx);
+    this.renderChildren();
   }
 
   getNext(key?: string|number): ParserNode {
@@ -27,7 +30,7 @@ export class ParserNode {
       // Scan the parent node to find the choice with the right number
       let idx = (typeof(key) === 'number') ? key : parseInt(key, 10);
       let choiceIdx = -1;
-      next = this.loopChildren((tag, child) => {
+      next = this.loopChildren((tag, child, orig) => {
         if (tag !== 'choice') {
           return;
         }
@@ -36,20 +39,59 @@ export class ParserNode {
           return;
         }
 
-        let result = child.children().eq(0);
+        // Use original node here, so we don't break dom structure
+        // due to child cloning/rendering.
+        let result = orig.children().eq(0);
         if (this.isElemEnabled(result)) {
           return result;
         }
         return this.getNextNode(result);
       }) || this.getNextNode();
     } else {
-      next = this.loopChildren((tag, c) => {
-        if (c.attr('on') === key) {
-          return c.children().eq(0);
+      next = this.loopChildren((tag, child, orig) => {
+        if (child.attr('on') === key) {
+          // Use original node here, so we don't break dom structure
+          // due to child cloning/rendering.
+          return orig.children().eq(0);
         }
       }) || null;
     }
     return (next) ? new ParserNode(next, this.ctx) : null;
+  }
+
+  // Evaluates all content ops in-place and creates a list of
+  // rendered (and therefore "enabled") child elements.
+  // Context is affected.
+  private renderChildren() {
+    this.renderedChildren = [];
+    for (let i = 0; i < this.elem.children().length; i++) {
+      let child = this.elem.children().eq(i);
+      if (!this.isElemEnabled(child)) {
+        continue;
+      }
+
+      let c = child.clone();
+
+      // Evaluate ops in attributes (cheerio uses attribs instead)
+      const attribs = (c.get(0) as any).attribs || c.get(0).attributes;
+      for (let j in attribs) {
+        if (!attribs.hasOwnProperty(j) && j != 'text') {
+          continue;
+        }
+        c.attr(j, evaluateContentOps(c.attr(j), this.ctx));
+      }
+
+      // Evaluate all non-control node bodies
+      if (!this.isElemControl(c)) {
+        let evaluated = evaluateContentOps(c.html(), this.ctx);
+        if (evaluated === '') {
+          continue;
+        }
+        c.html(evaluated);
+      }
+
+      this.renderedChildren.push({rendered: c, original: child});
+    }
   }
 
   gotoId(id: string): ParserNode {
@@ -60,16 +102,13 @@ export class ParserNode {
     return new ParserNode(search.eq(0), this.ctx);
   }
 
-  // Loop through all enabled children. If a call to cb() returns a value
+  // Loop through all rendered children. If a call to cb() returns a value
   // other than undefined, break the loop early and return the value.
-  loopChildren(cb: (tag: string, c: XMLElement)=>any): any {
-    for (let i = 0; i < this.elem.children().length; i++) {
-      let c = this.elem.children().eq(i);
-      if (!this.isElemEnabled(c)) {
-        continue;
-      }
-      let tag = this.elem.children().get(i).tagName.toLowerCase();
-      let v = cb(tag, c);
+  loopChildren(cb: (tag: string, child: XMLElement, original: XMLElement)=>any): any {
+    for (let i = 0; i < this.renderedChildren.length; i++) {
+      let c = this.renderedChildren[i];
+      let tag = this.renderedChildren[i].rendered.get(0).tagName.toLowerCase();
+      let v = cb(tag, c.rendered, c.original);
       if (v !== undefined) {
         return v;
       }
@@ -117,6 +156,9 @@ export class ParserNode {
   }
 
   private isElemEnabled(elem: XMLElement): boolean {
+    if (!elem) {
+      return false;
+    }
     const ifExpr = elem.attr('if');
     if (!ifExpr) {
       return true;

--- a/app/reducers/StateTypes.tsx
+++ b/app/reducers/StateTypes.tsx
@@ -18,7 +18,7 @@ export interface XMLElement {
   clone: () => XMLElement;
   find: (s: string) => XMLElementSet;
   get: (i: number) => DOMElement;
-  html: () => string;
+  html: (htmlString?: string) => string;
   length: number;
   next: () => XMLElement;
   parent: () => XMLElement;


### PR DESCRIPTION
This is a dependent PR on #294. Changes from de411e7 onward are new.

This effectively hides *all* op string parsing/rendering for cards behind ParserNode. This means that any `loadNode` style code (e.g. `loadCombatNode`) no longer needs to worry about contextual ops.