### PR TITLE
Plumbed usage of ParserNode through to Roleplay.tsx

### DIFF
--- a/app/actions/ActionTypes.tsx
+++ b/app/actions/ActionTypes.tsx
@@ -2,7 +2,8 @@ import Redux from 'redux'
 import {CardState, CardName, SettingNameType, SearchPhase, SearchSettings, SettingsType, TransitionType, UserState, XMLElement} from '../reducers/StateTypes'
 
 import {QuestContext, QuestDetails, Enemy, CombatPhaseNameType, DifficultyType} from '../reducers/QuestTypes'
-import {RoleplayResult, CombatResult} from '../parser/Handlers'
+import {CombatResult} from '../parser/Handlers'
+import {ParserNode} from '../parser/Node'
 
 export interface NavigateAction extends Redux.Action {
   type: 'NAVIGATE';
@@ -17,8 +18,7 @@ export interface ReturnAction extends Redux.Action {
 
 export interface QuestNodeAction extends Redux.Action {
   type: 'QUEST_NODE';
-  node: XMLElement;
-  result: RoleplayResult;
+  node: ParserNode;
   details?: QuestDetails;
 }
 
@@ -32,7 +32,7 @@ export interface InitCombatAction extends Redux.Action {
   numPlayers: number;
   difficulty: DifficultyType;
   result: CombatResult;
-  node?: XMLElement;
+  node?: ParserNode;
 }
 
 export interface CombatTimerStopAction extends Redux.Action {

--- a/app/components/CombatContainer.tsx
+++ b/app/components/CombatContainer.tsx
@@ -7,6 +7,7 @@ import {toPrevious, toCard} from '../actions/card'
 import {event, handleCombatTimerStop, combatDefeat, combatVictory, tierSumDelta, adventurerDelta} from '../actions/quest'
 import {AppStateWithHistory, XMLElement, SettingsType, CardName} from '../reducers/StateTypes'
 import {CombatPhaseNameType, MidCombatPhase, QuestContext} from '../reducers/QuestTypes'
+import {ParserNode} from '../parser/Node'
 
 declare var window:any;
 
@@ -31,7 +32,7 @@ const mapStateToProps = (state: AppStateWithHistory, ownProps: CombatStateProps)
       card: ownProps.card,
       settings: state.settings,
       maxTier: maxTier,
-      ctx: state.quest && state.quest.result && state.quest.result.ctx,
+      ctx: state.quest && state.quest.node && state.quest.node.ctx,
       combat: state.combat || {enemies: [], roundCount: 0, numAliveAdventurers: 0, tier: 0, roundTimeMillis: 0, surgePeriod: 0, damageMultiplier: 0},
     };
   } else {
@@ -41,7 +42,7 @@ const mapStateToProps = (state: AppStateWithHistory, ownProps: CombatStateProps)
       combat: Object.assign({}, ownProps.combat, {
         tier: state.combat && state.combat.tier,
         numAliveAdventurers: state.combat && state.combat.numAliveAdventurers}),
-      ctx: state.quest && state.quest.result && state.quest.result.ctx,
+      ctx: state.quest && state.quest.node && state.quest.node.ctx,
       node: ownProps.node,
       maxTier: maxTier,
       icon: ownProps.icon,
@@ -78,7 +79,7 @@ const mapDispatchToProps = (dispatch: Redux.Dispatch<any>, ownProps: any): Comba
       dispatch(toPrevious(cardName, 'PREPARE'));
     },
     onEvent: (node: XMLElement, evt: string, ctx: QuestContext) => {
-      dispatch(event(node, evt, ctx));
+      dispatch(event(new ParserNode(node, ctx), evt));
     },
     onTierSumDelta: (delta: number) => {
       dispatch(tierSumDelta(delta));

--- a/app/components/QuestStart.tsx
+++ b/app/components/QuestStart.tsx
@@ -1,15 +1,14 @@
 import * as React from 'react'
 import Card from './base/Card'
 import Button from './base/Button'
-import {XMLElement, SettingsType} from '../reducers/StateTypes'
+import {SettingsType} from '../reducers/StateTypes'
 
 export interface QuestStartStateProps {
-  node: XMLElement;
   settings: SettingsType;
 }
 
 export interface QuestStartDispatchProps {
-  onNext: (node: XMLElement) => void;
+  onNext: () => void;
 }
 
 export interface QuestStartProps extends QuestStartStateProps, QuestStartDispatchProps {};
@@ -39,7 +38,7 @@ const QuestStart = (props: QuestStartProps): JSX.Element => {
         a decision or hit the "Next" button during the story (not during combat).
       </p>}
 
-      <Button onTouchTap={() => props.onNext(props.node)}>Next</Button>
+      <Button onTouchTap={() => props.onNext()}>Next</Button>
     </Card>
   );
 }

--- a/app/components/QuestStartContainer.tsx
+++ b/app/components/QuestStartContainer.tsx
@@ -1,20 +1,19 @@
 import Redux from 'redux'
 import {connect} from 'react-redux'
-import {AppState, XMLElement} from '../reducers/StateTypes'
+import {AppState} from '../reducers/StateTypes'
 import {toCard, toPrevious} from '../actions/card'
 import QuestStart, {QuestStartStateProps, QuestStartDispatchProps} from './QuestStart'
 
 
 const mapStateToProps = (state: AppState, ownProps: any): QuestStartStateProps => {
   return {
-    node: state.quest.node,
     settings: state.settings,
   };
 }
 
 const mapDispatchToProps = (dispatch: Redux.Dispatch<any>, ownProps: any): QuestStartDispatchProps => {
   return {
-    onNext: (node: XMLElement) => {
+    onNext: () => {
       dispatch(toCard('QUEST_CARD'));
     }
   };

--- a/app/components/Roleplay.tsx
+++ b/app/components/Roleplay.tsx
@@ -2,25 +2,121 @@ import * as React from 'react'
 import Button from './base/Button'
 import Callout from './base/Callout'
 import Card from './base/Card'
-import {XMLElement, SettingsType} from '../reducers/StateTypes'
+import {SettingsType} from '../reducers/StateTypes'
+import {ParserNode} from '../parser/Node'
 import {Choice, QuestContext, RoleplayElement} from '../reducers/QuestTypes'
-import {RoleplayResult} from '../parser/Handlers'
 
 export interface RoleplayStateProps {
-  node: XMLElement;
-  roleplay: RoleplayResult;
+  node: ParserNode;
   settings: SettingsType;
-  ctx: QuestContext;
 }
 
 export interface RoleplayDispatchProps {
-  onChoice: (settings: SettingsType, node: XMLElement, index: number, ctx: QuestContext) => void;
+  onChoice: (settings: SettingsType, node: ParserNode, index: number) => void;
 }
 
 export interface RoleplayProps extends RoleplayStateProps, RoleplayDispatchProps {};
 
+// Replaces [icon_name] with <img class="inline_icon" src="images/icon_name.svg">
+function generateIconElements(content: string): string {
+  // \[([a-zA-Z_0-9]*)\]   Contents inside of []'s, only allowing for alphanumeric + _'s
+  // /g                    Multiple times
+  return content.replace(/\[([a-zA-Z_0-9]*)\]/g, (match:string, group:string): string => {
+    return `<img class="inline_icon" src="images/${group}_small.svg">`;
+  });
+}
+
+export interface RoleplayResult {
+  icon: string;
+  title: string;
+  content: RoleplayElement[];
+  choices: Choice[];
+  ctx: QuestContext;
+}
+
+export function loadRoleplayNode(node: ParserNode): RoleplayResult {
+  // Append elements to contents
+  let choices: Choice[] = [];
+  let choiceCount = -1;
+  let content: RoleplayElement[] = [];
+
+  node.loopChildren((tag, c) => {
+    c = c.clone();
+
+    // Accumulate 'choice' tags in choices[]
+    if (tag === 'choice') {
+      choiceCount++;
+      if (!c.attr('text')) {
+        throw new Error('<choice> inside <roleplay> must have "text" attribute');
+      }
+      const text = c.attr('text');
+      choices.push({text: generateIconElements(text), idx: choiceCount});
+      return;
+    }
+
+    if (tag === 'event') {
+      throw new Error('<roleplay> cannot contain <event>.');
+    }
+
+    const element: RoleplayElement = {
+      type: 'text',
+      text: '',
+    }
+    if (tag === 'instruction') {
+      element.type = 'instruction';
+      element.text = c.html();
+    } else { // text
+      // If we received a Cheerio object, outerHTML will
+      // not be defined. toString will be, however.
+      // https://github.com/cheeriojs/cheerio/issues/54
+      if (c.get(0).outerHTML) {
+        element.text = c.get(0).outerHTML;
+      } else if (c.toString) {
+        element.text = c.toString();
+      } else {
+        throw new Error('Invalid element ' + c);
+      }
+    }
+
+    element.text = generateIconElements(element.text);
+
+    if (element.text !== '') {
+      content.push(element);
+    }
+  });
+
+  // Append a generic 'Next' button if there were no choices,
+  // or an 'End' button if there's also an <End> tag.
+  if (choices.length === 0) {
+    // Handle custom generic next button text based on if we're heading into a trigger node.
+    const nextNode = node.getNext();
+    let buttonText = 'Next';
+    if (nextNode && nextNode.getTag() === 'trigger') {
+      switch(nextNode.elem.text().toLowerCase()) {
+        case 'end':
+          buttonText = 'End';
+          break;
+      }
+    }
+    choices.push({text: buttonText, idx: 0});
+  }
+
+  let title = node.elem.attr('title');
+  let icon = node.elem.attr('icon');
+  return {
+    title,
+    icon,
+    content,
+    choices,
+    ctx: node.ctx,
+  };
+}
+
+// TODO(scott): Convert this into a Template class implementation
 const Roleplay = (props: RoleplayProps): JSX.Element => {
-  const content: JSX.Element[] = props.roleplay.content.map((element: RoleplayElement, idx: number): JSX.Element => {
+  const rpResult = loadRoleplayNode(props.node)
+
+  const renderedContent: JSX.Element[] = rpResult.content.map((element: RoleplayElement, idx: number): JSX.Element => {
     switch (element.type) {
       case 'instruction':
         const matches = element.text.match(/src="images\/([a-zA-Z0-9_]*)/);
@@ -41,17 +137,18 @@ const Roleplay = (props: RoleplayProps): JSX.Element => {
         return <span key={idx} dangerouslySetInnerHTML={{__html: element.text}} />;
     }
   });
-  const buttons: JSX.Element[] = props.roleplay.choices.map((choice: Choice): JSX.Element => {
+
+  const buttons: JSX.Element[] = rpResult.choices.map((choice: Choice): JSX.Element => {
     return (
-      <Button key={choice.idx} onTouchTap={() => props.onChoice(props.settings, props.node, choice.idx, props.ctx)}>
+      <Button key={choice.idx} onTouchTap={() => props.onChoice(props.settings, props.node, choice.idx)}>
         <span dangerouslySetInnerHTML={{__html: choice.text}} />
       </Button>
     );
   });
 
   return (
-    <Card title={props.roleplay.title} inQuest={true}>
-      {content}
+    <Card title={rpResult.title} icon={rpResult.icon} inQuest={true}>
+      {renderedContent}
       {buttons}
     </Card>
   );

--- a/app/components/RoleplayContainer.tsx
+++ b/app/components/RoleplayContainer.tsx
@@ -5,20 +5,19 @@ import {toPrevious, toCard} from '../actions/card'
 import {choice} from '../actions/quest'
 import Roleplay, {RoleplayStateProps, RoleplayDispatchProps} from './Roleplay'
 import {QuestContext} from '../reducers/QuestTypes'
+import {ParserNode} from '../parser/Node'
 
 const mapStateToProps = (state: AppState, ownProps: RoleplayStateProps): RoleplayStateProps => {
   return {
-    ctx: state.quest && state.quest.result && state.quest.result.ctx,
-    node: state.quest && state.quest.node,
-    roleplay: ownProps.roleplay, // Persist state to prevent sudden jumps during card change.
+    node: ownProps.node, // Persist state to prevent sudden jumps during card change.
     settings: state.settings,
   };
 }
 
 const mapDispatchToProps = (dispatch: Redux.Dispatch<any>, ownProps: any): RoleplayDispatchProps => {
   return {
-    onChoice: (settings: SettingsType, node: XMLElement, index: number, ctx: QuestContext) => {
-      dispatch(choice(settings, node, index, ctx));
+    onChoice: (settings: SettingsType, node: ParserNode, index: number) => {
+      dispatch(choice(settings, node, index));
     },
   };
 }

--- a/app/components/base/Main.tsx
+++ b/app/components/base/Main.tsx
@@ -55,15 +55,15 @@ export default class Main extends React.Component<MainProps, {}> {
         card = <QuestStartContainer/>;
         break;
       case 'QUEST_CARD':
-        if (!state.quest || !state.quest.result) {
+        if (!state.quest || !state.quest.node) {
           return this.state;
         }
-        switch(state.quest.result.type) {
-          case 'Roleplay':
-            card = <RoleplayContainer node={state.quest.node} roleplay={state.quest.result}/>;
+        switch(state.quest.node.getTag()) {
+          case 'roleplay':
+            card = <RoleplayContainer node={state.quest.node}/>;
             break;
-          case 'Combat':
-            card = <CombatContainer card={state.card} node={state.quest.node} icon={state.quest.result.icon} combat={state.combat}/>;
+          case 'combat':
+            card = <CombatContainer card={state.card} node={state.quest.node.elem} icon={state.quest.result && state.quest.result.icon} combat={state.combat}/>;
             break;
           default:
             console.log('Unknown quest card name ' + name);

--- a/app/parser/Context.tsx
+++ b/app/parser/Context.tsx
@@ -88,6 +88,8 @@ function parseOpString(str: string): string {
 }
 
 export function updateContext(node: XMLElement, ctx: QuestContext): QuestContext {
+  if (!node) return ctx;
+
   const nodeId = node.attr('id');
   let newContext = Clone(ctx);
   if (nodeId) {

--- a/app/reducers/StateTypes.tsx
+++ b/app/reducers/StateTypes.tsx
@@ -1,5 +1,6 @@
 import {QuestDetails, CombatState, DifficultyType, CombatPhaseNameType, QuestContext} from './QuestTypes'
-import {CombatResult, RoleplayResult} from '../parser/Handlers'
+import {CombatResult} from '../parser/Handlers'
+import {ParserNode} from '../parser/Node'
 
 export type SettingNameType = 'numPlayers' | 'difficulty' | 'viewMode';
 
@@ -69,8 +70,8 @@ export type TransitionType = 'NEXT' | 'PREV' | 'INSTANT';
 
 export interface QuestState {
   details?: QuestDetails;
-  node?: XMLElement;
-  result?: CombatResult|RoleplayResult;
+  node?: ParserNode;
+  result?: CombatResult;
 }
 
 export interface SearchState {

--- a/app/reducers/combat.tsx
+++ b/app/reducers/combat.tsx
@@ -136,7 +136,7 @@ export function combat(state: CombatState, action: Redux.Action): CombatState {
     case 'INIT_COMBAT':
       let tierSum: number = 0;
       let combatAction = action as InitCombatAction;
-      let enemies: Enemy[] =  (combatAction.node) ? loadCombatNode(combatAction.node, combatAction.result.ctx).enemies : [];
+      let enemies: Enemy[] =  (combatAction.node) ? loadCombatNode(combatAction.node.elem, combatAction.result.ctx).enemies : [];
       for (let enemy of enemies) {
         tierSum += enemy.tier;
       }

--- a/app/reducers/quest.tsx
+++ b/app/reducers/quest.tsx
@@ -10,12 +10,10 @@ export function quest(state: QuestState = initial_state, action: Redux.Action): 
       return {...state,
         details: (action as QuestNodeAction).details || state.details,
         node: (action as QuestNodeAction).node,
-        result: (action as QuestNodeAction).result,
       };
     case 'INIT_COMBAT':
       return {...state,
         node: (action as InitCombatAction).node,
-        result: (action as InitCombatAction).result,
       };
     default:
       return state;


### PR DESCRIPTION
This keeps as much of the combat side of things the same, while using ParserNode in roleplay nodes. 

Also appearing in this pr is ParserNode.getTag(), a shortcut that makes sure we're comparing the same thing every time (no uppercase vs lowercase issues, for instance)

I also moved the rendering section of loadRoleplayNode to within Roleplay.tsx, as UI stuff shouldn't really be a part of the parser. XML attribute parsing is also broken out now and should present a cheerio/jquery agnostic view of things.