### PR TITLE
Move roleplay card into cardtemplates, abstract template usage

### DIFF
--- a/app/actions/quest.tsx
+++ b/app/actions/quest.tsx
@@ -8,7 +8,7 @@ import {toCard} from './card'
 import {handleAction} from '../parser/Handlers'
 import {QuestDetails, QuestContext} from '../reducers/QuestTypes'
 import {ParserNode} from '../parser/Node'
-import {initCombat} from '../cardtemplates/combat/Actions'
+import {initCardTemplate} from '../cardtemplates/template'
 
 export function initQuest(id: string, questNode: XMLElement, ctx: QuestContext): QuestNodeAction {
   const firstNode = questNode.children().eq(0);
@@ -35,31 +35,17 @@ export function choice(settings: SettingsType, node: ParserNode, index: number) 
 
 export function loadNode(settings: SettingsType, dispatch: Redux.Dispatch<any>, node: ParserNode) {
   var tag = node.getTag();
-  switch (tag) {
-    case 'trigger':
-      let triggerName = node.elem.text().trim();
-      if (triggerName === 'end') {
-        dispatch(toCard('QUEST_END'));
-        return;
-      } else {
-        throw new Error('invalid trigger ' + triggerName);
-      }
-    case 'roleplay':
-      // Every choice has an effect.
-      dispatch(toCard('QUEST_CARD', null));
 
-      // We set the quest state *after* the toCard() dispatch to prevent
-      // the history from grabbing the quest state before navigating.
-      // This bug manifests as toPrevious() sliding back to the same card
-      // content.
-      dispatch({type: 'QUEST_NODE', node} as QuestNodeAction);
-      break;
-    case 'combat':
-      dispatch(initCombat(node, settings));
-      break;
-    default:
-      throw new Error('Unsupported node type ' + tag);
+  if (tag === 'trigger') {
+    let triggerName = node.elem.text().trim();
+    if (triggerName === 'end') {
+      return dispatch(toCard('QUEST_END'));
+    } else {
+      throw new Error('invalid trigger ' + triggerName);
+    }
   }
+
+  return dispatch(initCardTemplate(node, settings));
 }
 
 export function event(node: ParserNode, evt: string) {

--- a/app/cardtemplates/combat/State.tsx
+++ b/app/cardtemplates/combat/State.tsx
@@ -32,26 +32,28 @@ export interface CombatState extends CombatDifficultySettings, MidCombatPhase, E
 
 export type CombatPhase = 'DRAW_ENEMIES' | 'PREPARE' | 'TIMER' | 'SURGE' | 'RESOLVE_ABILITIES' | 'ENEMY_TIER' | 'PLAYER_TIER' | 'VICTORY' | 'DEFEAT';
 
-export const CombatScope = {
-  randomEnemy: function(): string {
-    return randomPropertyValue(encounters).name;
-  },
-  randomEnemyOfTier: function(tier: number): string {
-    return randomPropertyValue(Object.assign({}, ...Object.keys(encounters)
-        .filter( key => encounters[key].tier === tier )
-        .map( key => ({ [key]: encounters[key] }) ) )).name;
-  },
-  randomEnemyOfClass: function(className: string): string {
-    className = className.toLowerCase();
-    return randomPropertyValue(Object.assign({}, ...Object.keys(encounters)
-        .filter( key => encounters[key].class.toLowerCase() === className )
-        .map( key => ({ [key]: encounters[key] }) ) )).name;
-  },
-  randomEnemyOfClassTier: function(className: string, tier: number): string {
-    className = className.toLowerCase();
-    return randomPropertyValue(Object.assign({}, ...Object.keys(encounters)
-        .filter( key => encounters[key].tier === tier )
-        .filter( key => encounters[key].class.toLowerCase() === className )
-        .map( key => ({ [key]: encounters[key] }) ) )).name;
-  },
-};
+export function combatScope() {
+  return {
+    randomEnemy: function(): string {
+      return randomPropertyValue(encounters).name;
+    },
+    randomEnemyOfTier: function(tier: number): string {
+      return randomPropertyValue(Object.assign({}, ...Object.keys(encounters)
+          .filter( key => encounters[key].tier === tier )
+          .map( key => ({ [key]: encounters[key] }) ) )).name;
+    },
+    randomEnemyOfClass: function(className: string): string {
+      className = className.toLowerCase();
+      return randomPropertyValue(Object.assign({}, ...Object.keys(encounters)
+          .filter( key => encounters[key].class.toLowerCase() === className )
+          .map( key => ({ [key]: encounters[key] }) ) )).name;
+    },
+    randomEnemyOfClassTier: function(className: string, tier: number): string {
+      className = className.toLowerCase();
+      return randomPropertyValue(Object.assign({}, ...Object.keys(encounters)
+          .filter( key => encounters[key].tier === tier )
+          .filter( key => encounters[key].class.toLowerCase() === className )
+          .map( key => ({ [key]: encounters[key] }) ) )).name;
+    },
+  };
+}

--- a/app/cardtemplates/roleplay/Actions.tsx
+++ b/app/cardtemplates/roleplay/Actions.tsx
@@ -1,0 +1,16 @@
+import Redux from 'redux'
+import {toCard} from '../../actions/card'
+import {SettingsType} from '../../reducers/StateTypes'
+import {ParserNode} from '../../parser/Node'
+import {QuestNodeAction} from '../../actions/ActionTypes'
+
+export function initRoleplay(node: ParserNode, settings: SettingsType, custom?: boolean) {
+  return (dispatch: Redux.Dispatch<any>): any => {
+    // We set the quest state *after* the toCard() dispatch to prevent
+    // the history from grabbing the quest state before navigating.
+    // This bug manifests as toPrevious() sliding back to the same card
+    // content.
+    dispatch(toCard('QUEST_CARD', null));
+    dispatch({type: 'QUEST_NODE', node} as QuestNodeAction);
+  };
+}

--- a/app/cardtemplates/roleplay/Roleplay.test.tsx
+++ b/app/cardtemplates/roleplay/Roleplay.test.tsx
@@ -2,9 +2,9 @@
 // useful tests without using import
 // (see: http://airbnb.io/enzyme/docs/guides/mocha.html)
 import Roleplay, {loadRoleplayNode, RoleplayResult} from './Roleplay'
-import {XMLElement} from '../reducers/StateTypes'
-import {defaultQuestContext, QuestContext} from '../reducers/QuestTypes'
-import {ParserNode} from '../parser/Node'
+import {XMLElement} from '../../reducers/StateTypes'
+import {defaultQuestContext, QuestContext} from '../../reducers/QuestTypes'
+import {ParserNode} from '../../parser/Node'
 
 var cheerio: any = require('cheerio');
 

--- a/app/cardtemplates/roleplay/Roleplay.tsx
+++ b/app/cardtemplates/roleplay/Roleplay.tsx
@@ -8,7 +8,6 @@ import {Choice, QuestContext, RoleplayElement} from '../../reducers/QuestTypes'
 
 export interface RoleplayStateProps {
   node: ParserNode;
-  card: any;
   settings: SettingsType;
 }
 

--- a/app/cardtemplates/roleplay/Roleplay.tsx
+++ b/app/cardtemplates/roleplay/Roleplay.tsx
@@ -1,13 +1,14 @@
 import * as React from 'react'
-import Button from './base/Button'
-import Callout from './base/Callout'
-import Card from './base/Card'
-import {SettingsType} from '../reducers/StateTypes'
-import {ParserNode} from '../parser/Node'
-import {Choice, QuestContext, RoleplayElement} from '../reducers/QuestTypes'
+import Button from '../../components/base/Button'
+import Callout from '../../components/base/Callout'
+import Card from '../../components/base/Card'
+import {SettingsType} from '../../reducers/StateTypes'
+import {ParserNode} from '../../parser/Node'
+import {Choice, QuestContext, RoleplayElement} from '../../reducers/QuestTypes'
 
 export interface RoleplayStateProps {
   node: ParserNode;
+  card: any;
   settings: SettingsType;
 }
 

--- a/app/cardtemplates/roleplay/RoleplayContainer.tsx
+++ b/app/cardtemplates/roleplay/RoleplayContainer.tsx
@@ -1,16 +1,18 @@
+import * as React from 'react'
 import Redux from 'redux'
 import {connect} from 'react-redux'
-import {AppState, XMLElement, SettingsType} from '../reducers/StateTypes'
-import {toPrevious, toCard} from '../actions/card'
-import {choice} from '../actions/quest'
+import {AppState, XMLElement, SettingsType} from '../../reducers/StateTypes'
+import {toPrevious, toCard} from '../../actions/card'
+import {choice} from '../../actions/quest'
 import Roleplay, {RoleplayStateProps, RoleplayDispatchProps} from './Roleplay'
-import {QuestContext} from '../reducers/QuestTypes'
-import {ParserNode} from '../parser/Node'
+import {QuestContext} from '../../reducers/QuestTypes'
+import {ParserNode} from '../../parser/Node'
 
 const mapStateToProps = (state: AppState, ownProps: RoleplayStateProps): RoleplayStateProps => {
   return {
     node: ownProps.node, // Persist state to prevent sudden jumps during card change.
     settings: state.settings,
+    card: ownProps.card,
   };
 }
 

--- a/app/cardtemplates/roleplay/RoleplayContainer.tsx
+++ b/app/cardtemplates/roleplay/RoleplayContainer.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react'
 import Redux from 'redux'
 import {connect} from 'react-redux'
 import {AppState, XMLElement, SettingsType} from '../../reducers/StateTypes'
@@ -12,7 +11,6 @@ const mapStateToProps = (state: AppState, ownProps: RoleplayStateProps): Rolepla
   return {
     node: ownProps.node, // Persist state to prevent sudden jumps during card change.
     settings: state.settings,
-    card: ownProps.card,
   };
 }
 

--- a/app/cardtemplates/template.tsx
+++ b/app/cardtemplates/template.tsx
@@ -26,7 +26,7 @@ export function initCardTemplate(node: ParserNode, settings: SettingsType) {
 export function renderCardTemplate(card: CardState, node: ParserNode): JSX.Element {
   switch(node.getTag()) {
     case 'roleplay':
-      return <RoleplayContainer card={card} node={node}/>;
+      return <RoleplayContainer node={node}/>;
     case 'combat':
       return <CombatContainer card={card} node={node}/>;
     default:

--- a/app/cardtemplates/template.tsx
+++ b/app/cardtemplates/template.tsx
@@ -1,0 +1,45 @@
+import Redux from 'redux'
+import * as React from 'react'
+import {ParserNode} from '../parser/Node'
+import {CardState, SettingsType} from '../reducers/StateTypes'
+
+import {initRoleplay} from './roleplay/Actions'
+import RoleplayContainer from './roleplay/RoleplayContainer'
+
+import {initCombat} from './combat/Actions'
+import CombatContainer from './combat/CombatContainer'
+import {combatScope, CombatState, CombatPhase} from '../cardtemplates/combat/State'
+
+export function initCardTemplate(node: ParserNode, settings: SettingsType) {
+  return (dispatch: Redux.Dispatch<any>): any => {
+    switch (node.getTag()) {
+      case 'roleplay':
+        return dispatch(initRoleplay(node, settings));
+      case 'combat':
+        return dispatch(initCombat(node, settings));
+      default:
+        throw new Error('Unsupported node type ' + node.getTag());
+    }
+  }
+}
+
+export function renderCardTemplate(card: CardState, node: ParserNode): JSX.Element {
+  switch(node.getTag()) {
+    case 'roleplay':
+      return <RoleplayContainer card={card} node={node}/>;
+    case 'combat':
+      return <CombatContainer card={card} node={node}/>;
+    default:
+      return null;
+  }
+}
+
+export function templateScope() {
+  return combatScope();
+}
+
+export interface TemplateState {
+  combat?: CombatState
+}
+
+export type TemplatePhase = CombatPhase;

--- a/app/components/base/Main.tsx
+++ b/app/components/base/Main.tsx
@@ -3,16 +3,16 @@ import {Provider} from 'react-redux'
 import theme from '../../theme'
 
 import AdvancedPlayContainer from '../AdvancedPlayContainer'
-import CombatContainer from '../../cardtemplates/combat/CombatContainer'
 import FeaturedQuestsContainer from '../FeaturedQuestsContainer'
 import PlayerCountSettingContainer from '../PlayerCountSettingContainer'
 import ReportContainer from '../ReportContainer'
-import RoleplayContainer from '../RoleplayContainer'
 import SearchContainer from '../SearchContainer'
 import SettingsContainer from '../SettingsContainer'
 import SplashScreenContainer from '../SplashScreenContainer'
 import QuestStartContainer from '../QuestStartContainer'
 import QuestEndContainer from '../QuestEndContainer'
+
+import {renderCardTemplate} from '../../cardtemplates/template'
 
 import {AppStateWithHistory, TransitionType, SearchPhase} from '../../reducers/StateTypes'
 import {getStore} from '../../store'
@@ -58,16 +58,10 @@ export default class Main extends React.Component<MainProps, {}> {
         if (!state.quest || !state.quest.node) {
           return this.state;
         }
-        switch(state.quest.node.getTag()) {
-          case 'roleplay':
-            card = <RoleplayContainer node={state.quest.node}/>;
-            break;
-          case 'combat':
-            card = <CombatContainer card={state.card} node={state.quest.node}/>;
-            break;
-          default:
-            console.log('Unknown quest card name ' + name);
-            return this.state;
+        card = renderCardTemplate(state.card, state.quest.node);
+        if (!card) {
+          console.log('Unknown quest card name ' + name);
+          return this.state;
         }
         break;
       case 'QUEST_END':

--- a/app/reducers/QuestTypes.tsx
+++ b/app/reducers/QuestTypes.tsx
@@ -1,6 +1,6 @@
 
 import {getStore} from '../store'
-import {CombatScope, CombatState} from '../cardtemplates/combat/State'
+import {templateScope, TemplateState} from '../cardtemplates/template'
 
 export interface QuestDetails {
   id?: string;
@@ -27,9 +27,7 @@ export interface QuestContext {
   // nodes that are potentially parseable via MathJS.
   scope: any; // TODO: required fields later
   views: any; // TODO: {string: number}
-  templates: {
-    combat?: CombatState
-  };
+  templates: TemplateState;
 }
 export function defaultQuestContext(): QuestContext {
   // Caution: Scope is the API for Quest Creators.
@@ -45,7 +43,7 @@ export function defaultQuestContext(): QuestContext {
         viewCount: function(id: string): number {
           return this.views[id] || 0;
         },
-        ...CombatScope
+        ...templateScope()
       },
     },
     views: {},

--- a/app/reducers/StateTypes.tsx
+++ b/app/reducers/StateTypes.tsx
@@ -1,5 +1,5 @@
 import {QuestDetails, DifficultyType, QuestContext} from './QuestTypes'
-import {CombatPhase} from '../cardtemplates/combat/State'
+import {TemplatePhase} from '../cardtemplates/template'
 import {ParserNode} from '../parser/Node'
 
 export type SettingNameType = 'numPlayers' | 'difficulty' | 'viewMode';
@@ -59,7 +59,7 @@ export interface SettingsType {
 }
 
 export type CardName = 'PLAYER_COUNT_SETTING' | 'QUEST_START' | 'QUEST_END' | 'QUEST_CARD' | 'FEATURED_QUESTS' | 'SPLASH_CARD' | 'SEARCH_CARD' | 'SETTINGS' | 'ADVANCED' | 'REPORT';
-export type CardPhase = CombatPhase | SearchPhase;
+export type CardPhase = TemplatePhase | SearchPhase;
 export interface CardState {
   name: CardName;
   ts: number;


### PR DESCRIPTION
This should be the last step to almost fully partitioning actual card action handling from other non-quest components and state. 