### PR TITLE
Allow travis to cache node_modules

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,3 +10,6 @@ addons:
     packages:
     - g++-4.8
 before_deploy: "webpack -p --config ./webpack.dist.config.js"
+cache:
+  directories:
+    - node_modules


### PR DESCRIPTION
This should greatly increase CI run speed.