### PR TITLE
Expose round and surge details via op functions, fix op function binding

### DIFF
--- a/app/cardtemplates/combat/Actions.test.tsx
+++ b/app/cardtemplates/combat/Actions.test.tsx
@@ -1,4 +1,4 @@
-import {initCombat, initCustomCombat, isSurgeRound, handleCombatTimerStop, handleCombatEnd, tierSumDelta, adventurerDelta, handleResolvePhase, midCombatChoice} from './Actions'
+import {initCombat, initCustomCombat, isSurgeNextRound, handleCombatTimerStop, handleCombatEnd, tierSumDelta, adventurerDelta, handleResolvePhase, midCombatChoice} from './Actions'
 import {DifficultyType} from '../../reducers/QuestTypes'
 import {defaultQuestContext} from '../../reducers/Quest'
 import {ParserNode} from '../../parser/Node'
@@ -82,17 +82,17 @@ describe('Combat actions', () => {
     });
   });
 
-  describe('isSurgeRound', () => {
+  describe('isSurgeNextRound', () => {
     it('surges according to the period', () => {
       // "Play" until surge
       const store = mockStore({});
       let node = newCombatNode();
-      for(let i = 0; i < 10 && (!node || !isSurgeRound(node)); i++) {
+      for(let i = 0; i < 10 && (!node || !isSurgeNextRound(node)); i++) {
         store.clearActions();
         store.dispatch(handleCombatTimerStop(node, TEST_SETTINGS, 1000));
         node = store.getActions()[1].node;
       }
-      expect(isSurgeRound(node)).toEqual(true);
+      expect(isSurgeNextRound(node)).toEqual(true);
 
       // Count time till next surge
       let pd = 0;
@@ -101,7 +101,7 @@ describe('Combat actions', () => {
         store.dispatch(handleCombatTimerStop(node, TEST_SETTINGS, 1000));
         node = store.getActions()[1].node;
         pd++;
-      } while (pd < 10 && !isSurgeRound(node));
+      } while (pd < 10 && !isSurgeNextRound(node));
       expect(pd).toEqual(3); // Default for normal difficulty
     });
   });

--- a/app/cardtemplates/combat/Actions.test.tsx
+++ b/app/cardtemplates/combat/Actions.test.tsx
@@ -90,7 +90,13 @@ describe('Combat actions', () => {
       for(let i = 0; i < 10 && (!node || !isSurgeNextRound(node)); i++) {
         store.clearActions();
         store.dispatch(handleCombatTimerStop(node, TEST_SETTINGS, 1000));
-        node = store.getActions()[1].node;
+        const actions = store.getActions();
+        for (const a of actions) {
+          if (a.type === 'QUEST_NODE') {
+            node = a.node;
+            break;
+          }
+        }
       }
       expect(isSurgeNextRound(node)).toEqual(true);
 
@@ -99,7 +105,13 @@ describe('Combat actions', () => {
       do {
         store.clearActions();
         store.dispatch(handleCombatTimerStop(node, TEST_SETTINGS, 1000));
-        node = store.getActions()[1].node;
+        const actions = store.getActions();
+        for (const a of actions) {
+          if (a.type === 'QUEST_NODE') {
+            node = a.node;
+            break;
+          }
+        }
         pd++;
       } while (pd < 10 && !isSurgeNextRound(node));
       expect(pd).toEqual(3); // Default for normal difficulty

--- a/app/cardtemplates/combat/Actions.tsx
+++ b/app/cardtemplates/combat/Actions.tsx
@@ -68,7 +68,7 @@ function generateCombatAttack(node: ParserNode, settings: SettingsType, elapsedM
   damage = Math.min(10, damage);
 
   return {
-    surge: isSurgeRound(node),
+    surge: isSurgeNextRound(node),
     damage,
   }
 }
@@ -134,10 +134,14 @@ function randomAttackDamage() {
   }
 };
 
-export function isSurgeRound(node: ParserNode): boolean {
+export function isSurgeRound(rounds: number, surgePd: number): boolean {
+  return (surgePd - ((rounds - 1) % surgePd + 1)) === 0;
+}
+
+export function isSurgeNextRound(node: ParserNode): boolean {
   const rounds = node.ctx.templates.combat.roundCount;
   const surgePd = node.ctx.templates.combat.surgePeriod;
-  return (surgePd - (rounds % surgePd + 1)) === 0;
+  return isSurgeRound(rounds + 1, surgePd);
 }
 
 export function handleResolvePhase(node: ParserNode) {
@@ -213,8 +217,12 @@ export function handleCombatTimerStop(node: ParserNode, settings: SettingsType, 
     node.ctx.templates.combat.roundCount++;
 
     if (node.ctx.templates.combat.mostRecentAttack.surge) {
-      dispatch(toCard('QUEST_CARD', 'SURGE', true));
+      // Since we always skip the previous card (the timer) when going back,
+      // We can preset the quest node here. This populates context in a way that
+      // the latest round is considered when the "on round" branch is evaluated.
       dispatch({type: 'QUEST_NODE', node: node} as QuestNodeAction);
+      dispatch(toCard('QUEST_CARD', 'SURGE', true));
+
     } else {
       dispatch(handleResolvePhase(node));
     }

--- a/app/cardtemplates/combat/Combat.tsx
+++ b/app/cardtemplates/combat/Combat.tsx
@@ -145,7 +145,6 @@ function renderSurge(props: CombatProps): JSX.Element {
       </span>
     );
   }
-  console.log(props.node.ctx.templates.combat.roundCount);
   return (
     <Card title="Enemy Surge!"
       theme="RED"

--- a/app/cardtemplates/combat/Combat.tsx
+++ b/app/cardtemplates/combat/Combat.tsx
@@ -7,7 +7,7 @@ import TimerCard from '../../components/base/TimerCard'
 import theme from '../../Theme'
 import {MAX_ADVENTURER_HEALTH, REGEX} from '../../Constants'
 import {encounters} from '../../Encounters'
-import {isSurgeRound} from './Actions'
+import {isSurgeNextRound} from './Actions'
 import {SettingsType, CardState, CardName} from '../../reducers/StateTypes'
 import {ParserNode} from '../../parser/Node'
 import {QuestContext, EventParameters, Enemy, Loot} from '../../reducers/QuestTypes'
@@ -33,6 +33,7 @@ export interface CombatDispatchProps {
   onEvent: (node: ParserNode, event: string) => void;
   onCustomEnd: () => void;
   onChoice: (settings: SettingsType, parent: ParserNode, index: number) => void;
+  onSurgeNext: (node: ParserNode) => void;
 }
 
 export interface CombatProps extends CombatStateProps, CombatDispatchProps {};
@@ -144,6 +145,7 @@ function renderSurge(props: CombatProps): JSX.Element {
       </span>
     );
   }
+  console.log(props.node.ctx.templates.combat.roundCount);
   return (
     <Card title="Enemy Surge!"
       theme="RED"
@@ -152,7 +154,7 @@ function renderSurge(props: CombatProps): JSX.Element {
     >
       <h3>An enemy surge occurs!</h3>
       {helpText}
-      <Button onTouchTap={() => props.onNext('RESOLVE_ABILITIES')}>Next</Button>
+      <Button onTouchTap={() => props.onSurgeNext(props.node)}>Next</Button>
     </Card>
   );
 }
@@ -310,7 +312,7 @@ function renderDefeat(props: CombatProps): JSX.Element {
 }
 
 function renderTimerCard(props: CombatProps): JSX.Element {
-  const surge = isSurgeRound(props.node);
+  const surge = isSurgeNextRound(props.node);
   const surgeWarning = (props.settings.difficulty === 'EASY' && surge) ? 'Surge Imminent' : null;
   let instruction = null;
   if (props.settings.showHelp) {

--- a/app/cardtemplates/combat/CombatContainer.tsx
+++ b/app/cardtemplates/combat/CombatContainer.tsx
@@ -12,7 +12,7 @@ import {QuestContext, EventParameters} from '../../reducers/QuestTypes'
 import {CombatPhase, MidCombatPhase} from './State'
 import {ParserNode} from '../../parser/Node'
 import {MAX_ADVENTURER_HEALTH} from '../../Constants'
-import {midCombatChoice} from './Actions'
+import {midCombatChoice, handleResolvePhase} from './Actions'
 import {logEvent} from '../../React'
 
 declare var window:any;
@@ -80,6 +80,9 @@ const mapDispatchToProps = (dispatch: Redux.Dispatch<any>, ownProps: any): Comba
     },
     onTimerStop: (node: ParserNode, settings: SettingsType, elapsedMillis: number, surge: boolean) => {
       dispatch(handleCombatTimerStop(node, settings, elapsedMillis));
+    },
+    onSurgeNext: (node: ParserNode) => {
+      dispatch(handleResolvePhase(node));
     },
     onReturn: () => {postTimerReturn(dispatch)},
     onEvent: (node: ParserNode, evt: string) => {

--- a/app/cardtemplates/combat/State.tsx
+++ b/app/cardtemplates/combat/State.tsx
@@ -1,6 +1,7 @@
 import {encounters} from '../../Encounters'
 import {Enemy, Loot} from '../../reducers/QuestTypes'
 import {ParserNode} from '../../parser/Node'
+import {isSurgeRound} from './Actions'
 
 export interface CombatAttack {
   surge: boolean;
@@ -55,6 +56,12 @@ export function combatScope() {
           .filter( key => encounters[key].tier === tier )
           .filter( key => encounters[key].class.toLowerCase() === className )
           .map( key => ({ [key]: encounters[key] }) ) )).name;
+    },
+    currentCombatRound: function(): number {
+      return this.templates.combat.roundCount || 0;
+    },
+    isCombatSurgeRound: function(): boolean {
+      return isSurgeRound(this.templates.combat.roundCount, this.templates.combat.surgePeriod);
     },
   };
 }

--- a/app/parser/Context.tsx
+++ b/app/parser/Context.tsx
@@ -114,11 +114,10 @@ export function updateContext(node: Cheerio, ctx: QuestContext, action?: string|
     newContext.path.push(action);
   }
 
-  // TODO(scott): This is a hack to remove dependency on defaultQuestContext, which adds a bunch
-  // of unnecessary dependencies in the quest service.
-  newContext.scope._.viewCount = function(id: string): number {
-    return this.views[id] || 0;
-  }.bind(newContext);
-
+  // Create new copies of all scope functions and bind them
+  newContext.scope._ = newContext._templateScopeFn();
+  for (const k of Object.keys(newContext.scope._)) {
+    newContext.scope._[k] = (newContext.scope._[k] as any).bind(newContext);
+  }
   return newContext;
 }

--- a/app/quests/test_quest.xml
+++ b/app/quests/test_quest.xml
@@ -18,6 +18,9 @@
         <event on="round">
           <roleplay data-line="32">
             <p>A round card during combat!</p>
+            <p>Current round: {{_.currentCombatRound()}}</p>
+            <p>Surge round: {{string(_.isCombatSurgeRound())}}</p>
+            <p>Random enemy: {{_.randomEnemy()}}</p>
             <choice text="A choice">
               <roleplay data-line="33">
                 <p>Another card</p>

--- a/app/reducers/Quest.tsx
+++ b/app/reducers/Quest.tsx
@@ -11,26 +11,37 @@ export const initialState: QuestState = {
 };
 
 export function defaultQuestContext(): QuestContext {
+  const populateScopeFn = function() {
+    return {
+      numAdventurers: function(): number {
+        const settings = getStore().getState().settings;
+        return settings && settings.numPlayers;
+      },
+      viewCount: function(id: string): number {
+        return this.views[id] || 0;
+      },
+      ...templateScope(),
+    };
+  };
+
   // Caution: Scope is the API for Quest Creators.
   // New endpoints should be added carefully b/c we'll have to support them.
   // Behind-the-scenes data can be added to the context outside of scope
-  return {
+  const newContext: QuestContext = {
     scope: {
-      _: {
-        numAdventurers: function(): number {
-          const settings = getStore().getState().settings;
-          return settings && settings.numPlayers;
-        },
-        viewCount: function(id: string): number {
-          return this.views[id] || 0;
-        },
-        ...templateScope()
-      },
+      _: populateScopeFn(),
     },
     views: {},
     templates: {},
-    path: [],
+    path: ([] as any),
+    _templateScopeFn: populateScopeFn, // Used to refill template scope elsewhere (without dependencies)
   };
+
+  for (const k of Object.keys(newContext.scope._)) {
+    newContext.scope._[k] = (newContext.scope._[k] as any).bind(newContext);
+  }
+
+  return newContext;
 }
 
 export function quest(state: QuestState = initialState, action: Redux.Action): QuestState {

--- a/app/reducers/QuestTypes.tsx
+++ b/app/reducers/QuestTypes.tsx
@@ -12,6 +12,9 @@ export interface QuestContext {
   // Given the path and original quest XML, we should be able to recreate
   // context given this path.
   path: (string|number)[];
+
+  // Regenerate template scope (all of "_") with this function.
+  _templateScopeFn: () => any;
 }
 
 export interface QuestDetails {


### PR DESCRIPTION
This exposes `_.currentCombatRound()` and `_.isCombatSurgeRound()`, which can be used to conditionally show/hide the new `* on round` combat event. This branch is also now followed after surge cards.

Added a few extra bits to the test quest to show this off.