### PR TITLE
Fix several performance issues in rendering code

### DIFF
--- a/app/components/base/AppContainer.tsx
+++ b/app/components/base/AppContainer.tsx
@@ -24,11 +24,18 @@ interface MainProps extends React.Props<any> {}
 
 export default class Main extends React.Component<MainProps, {}> {
   state: {key: number, transition: TransitionType, card: JSX.Element, snackbar: SnackbarState};
+  storeUnsubscribeHandle: () => any;
 
   constructor(props: MainProps) {
     super(props);
     this.state = this.getUpdatedState();
-    getStore().subscribe(this.handleChange.bind(this));
+    this.storeUnsubscribeHandle = getStore().subscribe(this.handleChange.bind(this));
+  }
+
+  componentWillUnmount() {
+    // 2017-08-16: Failing to unsubscribe here is likely to have caused unnecessary references to previous
+    // JS objects, which prevents garbage collection and causes runaway memory consumption.
+    this.storeUnsubscribeHandle();
   }
 
   getUpdatedState() {

--- a/app/components/base/MultiTouchTrigger.tsx
+++ b/app/components/base/MultiTouchTrigger.tsx
@@ -22,41 +22,61 @@ export default class MultiTouchTrigger extends React.Component<MultiTouchTrigger
   canvas: any;
   inputArray: number[][];
   mouseDown: Boolean;
+  private listeners: {[k: string]: () => void};
+  private boundDrawTouchPoints: () => void;
 
-  _touchEvent(e: any) {
+  constructor(props: MultiTouchTriggerProps) {
+    super(props);
+    // We track bound listener functions in this way so we can unsubscribe
+    // them later.
+    this.listeners = {
+      'touchstart': this.touchEvent.bind(this),
+      'touchmove': this.touchEvent.bind(this),
+      'touchend': this.touchEvent.bind(this),
+      'mousedown': this.mouseDownEvent.bind(this),
+      'mousemove': this.mouseMoveEvent.bind(this),
+      'mouseup': this.mouseUpEvent.bind(this),
+    };
+    this.boundDrawTouchPoints = this.drawTouchPoints.bind(this);
+  }
+
+  private touchEvent(e: any) {
     const xyArray: number[][] = [];
     for (let i = 0; i < e.touches.length; i++) {
       xyArray.push([e.touches[i].clientX, e.touches[i].clientY]);
     }
-    this._processInput(xyArray);
+    this.processInput(xyArray);
     e.preventDefault();
   }
 
-  _mouseDownEvent(e: any) {
+  private mouseDownEvent(e: any) {
     this.mouseDown = true;
-    this._processInput([[e.layerX, e.layerY]]);
+    this.processInput([[e.layerX, e.layerY]]);
   }
 
-  _mouseMoveEvent(e: any) {
+  private mouseMoveEvent(e: any) {
     if (this.mouseDown) {
-      this._processInput([[e.layerX, e.layerY]]);
+      this.processInput([[e.layerX, e.layerY]]);
     }
   }
 
-  _mouseUpEvent() {
+  private mouseUpEvent() {
     this.mouseDown = false;
-    this._processInput([]);
+    this.processInput([]);
   }
 
-  _processInput(xyArray: number[][]) {
+  private processInput(xyArray: number[][]) {
     if (!Boolean(this.inputArray) || xyArray.length !== this.inputArray.length) {
       this.props.onTouchChange(xyArray.length);
     }
     this.inputArray = xyArray;
+
+    // Request a single animation frame every time our input values change,
+    // instead of rendering continuously (saves render load).
+    window.requestAnimationFrame(this.boundDrawTouchPoints);
   }
 
-  _drawTouchPoints() {
-
+  private drawTouchPoints() {
     const inputs = this.inputArray;
     this.ctx.clearRect(0, 0, this.ctx.canvas.width, this.ctx.canvas.height);
     for (let i = 0; i < inputs.length; i++) {
@@ -70,11 +90,16 @@ export default class MultiTouchTrigger extends React.Component<MultiTouchTrigger
       this.ctx.arc(inputs[i][0], inputs[i][1], styles.ring.radius, 0, 2 * Math.PI, false);
       this.ctx.stroke();
     }
-    window.requestAnimationFrame(() => {this._drawTouchPoints(); });
   }
 
   setupCanvas(ref: any) {
+    // We have nothing to do if we're given the same canvas as previous.
+    if (this.canvas === ref) {
+      return;
+    }
+
     // Setup canvas element and touch listeners
+    this.destroyCanvas();
     this.canvas = ref;
     if (!this.canvas) {
       return;
@@ -82,20 +107,31 @@ export default class MultiTouchTrigger extends React.Component<MultiTouchTrigger
     this.ctx = this.canvas.getContext('2d');
     this.ctx.canvas.width = window.innerWidth;
     this.ctx.canvas.height = window.innerHeight;
-    this.canvas.addEventListener('touchstart', this._touchEvent.bind(this));
-    this.canvas.addEventListener('touchmove', this._touchEvent.bind(this));
-    this.canvas.addEventListener('touchend', this._touchEvent.bind(this));
-    this.canvas.addEventListener('mousedown', this._mouseDownEvent.bind(this));
-    this.canvas.addEventListener('mousemove', this._mouseMoveEvent.bind(this));
-    this.canvas.addEventListener('mouseup', this._mouseUpEvent.bind(this));
+    for (const k of Object.keys(this.listeners)) {
+      this.canvas.addEventListener(k, this.listeners[k]);
+    }
 
-    this._touchEvent({touches: [], preventDefault: ()=>{}});
-    window.requestAnimationFrame(() => {this._drawTouchPoints(); });
+    this.touchEvent({touches: [], preventDefault: ()=>{}});
+    window.requestAnimationFrame(this.boundDrawTouchPoints);
+  }
+
+  private destroyCanvas() {
+    if (!this.canvas) {
+      return;
+    }
+    // Remove event listener references from canvas so they don't stick around.
+    for (const k of Object.keys(this.listeners)) {
+      this.canvas.removeEventListener(k, this.listeners[k]);
+    }
+  }
+
+  componentWillUnmount() {
+    this.destroyCanvas();
   }
 
   render() {
     return (
-       <canvas className="base_multi_touch_trigger" ref={this.setupCanvas.bind(this)} />
+       <canvas className="base_multi_touch_trigger" ref={(ref: any) => {this.setupCanvas(ref);}} />
     );
   }
 }

--- a/app/components/base/MultiTouchTrigger.tsx
+++ b/app/components/base/MultiTouchTrigger.tsx
@@ -110,9 +110,7 @@ export default class MultiTouchTrigger extends React.Component<MultiTouchTrigger
     for (const k of Object.keys(this.listeners)) {
       this.canvas.addEventListener(k, this.listeners[k]);
     }
-
     this.touchEvent({touches: [], preventDefault: ()=>{}});
-    window.requestAnimationFrame(this.boundDrawTouchPoints);
   }
 
   private destroyCanvas() {


### PR DESCRIPTION
Before (during timer):

![runaway heap growth example pattern](https://user-images.githubusercontent.com/607666/29616160-881a4208-87de-11e7-8835-8a7075a8d824.PNG)

After (long period of interaction, followed by GC):

![corrected heap growth with GC at end](https://user-images.githubusercontent.com/607666/29616152-858f09ba-87de-11e7-893b-f220bb16ecd8.PNG)

Notice that the final result memory is roughly the same as before the long interaction with combat and cards.
