### PR TITLE
Remove call to super() of undefined method

### DIFF
--- a/app/components/base/RemoteTouchPanel.tsx
+++ b/app/components/base/RemoteTouchPanel.tsx
@@ -36,7 +36,6 @@ export default class RemoteTouchPanel extends TouchPanel {
   }
 
   componentWillUnmount() {
-    super.componentWillUnmount();
     getRemotePlayClient().unsubscribe(this.boundHandleRemotePlayEvent);
   }
 }


### PR DESCRIPTION
I added this back when TouchPanel had a componentWillUnmount() function, but I removed that function in a cleanup CL. This CL removes the child class call to `super`, which unbreaks the app.