### PR TITLE
Remote Play: Support quest loading, roleplay, (buggy) combat

### DIFF
--- a/app/Main.tsx
+++ b/app/Main.tsx
@@ -20,6 +20,11 @@ import {getWindow, getGapi, getGA, getDevicePlatform, getDocument, setGA, setupP
 import {getRemotePlayClient} from './RemotePlay'
 import {RemotePlayEvent} from 'expedition-qdl/lib/remote/Events'
 
+// Thunk is unused, but necessary to prevent compiler errors
+// until types are fixed for remote play.
+// TODO: Fix redux types
+import thunk from 'redux-thunk'
+
 
 const injectTapEventPlugin = require('react-tap-event-plugin');
 

--- a/app/Testing.tsx
+++ b/app/Testing.tsx
@@ -53,10 +53,10 @@ export function Reducer<A extends Redux.Action>(reducer: (state: Object, action:
   };
 }
 
-export function Action<A>(action: (a: A) => Redux.Action) {
+export function Action<A>(action: (a: A) => Redux.Action, baseState?: Object) {
   const client = new RemotePlayClient();
   client.sendEvent = jasmine.createSpy('sendEvent');
-  let store = configureStore([client.createActionMiddleware()])({});
+  let store = configureStore([client.createActionMiddleware()])(baseState || {});
 
   function internalActionCommands() {
     return {

--- a/app/actions/ActionTypes.tsx
+++ b/app/actions/ActionTypes.tsx
@@ -1,8 +1,12 @@
 import Redux from 'redux'
-import {CardState, CardName, CardPhase, DialogIDType, SearchPhase, SearchSettings, SettingsType, TransitionType, UserState, SessionMetadata} from '../reducers/StateTypes'
+import {CardState, CardName, CardPhase, DialogIDType, SearchPhase, SearchSettings, SettingsType, TransitionType, UserState, SessionMetadata, AppState} from '../reducers/StateTypes'
 import {QuestDetails} from '../reducers/QuestTypes'
 import {ParserNode} from '../cardtemplates/Template'
 import {Session} from 'expedition-qdl/lib/remote/Broker'
+
+export interface PushHistoryAction extends Redux.Action {
+  type: 'PUSH_HISTORY';
+}
 
 export interface AnnouncementSetAction extends Redux.Action {
   type: 'ANNOUNCEMENT_SET';
@@ -115,12 +119,12 @@ export interface RemotePlayHistoryAction extends Redux.Action {
   history: SessionMetadata[];
 }
 
-// RemotePlayActions wrap an existing action; this is so that inbound
+// LocalActions wrap an existing action; this is so that inbound
 // actions to the redux dispatch middleware that were created from
 // another client's interaction are not re-broadcast in an endless loop
 // to other clients.
-export interface RemotePlayAction extends Redux.Action {
-  type: 'REMOTE_PLAY_ACTION';
+export interface LocalAction extends Redux.Action {
+  type: 'LOCAL';
   action: Redux.Action;
 }
 
@@ -128,7 +132,7 @@ export interface RemotePlayAction extends Redux.Action {
 // This array can be passed to the generated RemotePlay redux middleware
 // which invokes it and packages it to send to other remote play clients.
 const REMOTE_ACTIONS: {[action: string]: (args: any) => Redux.Action} = {}
-export function remoteify<A>(a: (args: A, dispatch?: Redux.Dispatch<any>)=>any) {
+export function remoteify<A>(a: (args: A, dispatch?: Redux.Dispatch<any>, getState?: ()=>AppState)=>any) {
   const remoted = (args: A) => {
     return ([a.name, a, args] as any) as Redux.Action; // We know better >:}
   }

--- a/app/actions/Card.test.tsx
+++ b/app/actions/Card.test.tsx
@@ -1,6 +1,4 @@
 import configureStore  from 'redux-mock-store'
-import thunk from 'redux-thunk'
-import {installStore} from '../Store'
 import {toCard, toPrevious} from './Card'
 import {setNavigator} from '../Globals'
 import {RemotePlayClient} from '../RemotePlay'
@@ -19,18 +17,14 @@ describe('Card action', () => {
     setNavigator(navigator);
 
     it('causes vibration if vibration enabled', () => {
-      const store = mockStore({settings: {vibration: true}});
-      installStore(store);
       spyOn(navigator, 'vibrate');
-      Action(toCard).execute({name: 'QUEST_CARD'});
+      Action(toCard, {settings: {vibration: true}}).execute({name: 'QUEST_CARD'});
       expect(navigator.vibrate).toHaveBeenCalledTimes(1);
     });
 
     it('does not vibrate if vibration not enabled', () => {
-      const store = mockStore({settings: {vibration: false}});
-      installStore(store);
       spyOn(navigator, 'vibrate');
-      Action(toCard).execute({name: 'QUEST_CARD'});
+      Action(toCard, {settings: {vibration: false}}).execute({name: 'QUEST_CARD'});
       expect(navigator.vibrate).toHaveBeenCalledTimes(0);
     });
 

--- a/app/actions/Card.tsx
+++ b/app/actions/Card.tsx
@@ -3,23 +3,25 @@ import {NavigateAction, ReturnAction, remoteify} from './ActionTypes'
 import {AppStateWithHistory, CardName, CardPhase, CardState} from '../reducers/StateTypes'
 import {VIBRATION_LONG_MS, VIBRATION_SHORT_MS} from '../Constants'
 import {getNavigator} from '../Globals'
-import {getStore} from '../Store'
 import {getRemotePlayClient} from '../RemotePlay'
 
 interface ToCardArgs {
   name: CardName;
   phase?: CardPhase;
   overrideDebounce?: boolean;
+  noHistory?: boolean;
 }
-export const toCard = remoteify(function toCard(a: ToCardArgs, dispatch?: Redux.Dispatch<any>): ToCardArgs {
-  const state: AppStateWithHistory = getStore().getState();
+export const toCard = remoteify(function toCard(a: ToCardArgs, dispatch?: Redux.Dispatch<any>, getState?: ()=>AppStateWithHistory): ToCardArgs {
   const nav = getNavigator();
-  if (nav && nav.vibrate && state.settings.vibration) {
+  if (nav && nav.vibrate && getState().settings.vibration) {
     if (a.phase === 'TIMER') {
       nav.vibrate(VIBRATION_LONG_MS);
     } else {
       nav.vibrate(VIBRATION_SHORT_MS);
     }
+  }
+  if (!a.noHistory) {
+    dispatch({type: 'PUSH_HISTORY'});
   }
   dispatch({type: 'NAVIGATE', to: {...a, ts: Date.now()}} as NavigateAction);
 
@@ -46,7 +48,7 @@ export const toPrevious = remoteify(function toPrevious(a?: ToPreviousArgs, disp
 
   dispatch(result);
 
-  return result;
+  return a;
 });
 
 // TODO: getRemotePlayClient().registerModuleActions(module);

--- a/app/actions/Card.tsx
+++ b/app/actions/Card.tsx
@@ -13,7 +13,9 @@ interface ToCardArgs {
 }
 export const toCard = remoteify(function toCard(a: ToCardArgs, dispatch?: Redux.Dispatch<any>, getState?: ()=>AppStateWithHistory): ToCardArgs {
   const nav = getNavigator();
-  if (nav && nav.vibrate && getState().settings.vibration) {
+  const state = getState();
+  const vibration = state.settings && state.settings.vibration;
+  if (nav && nav.vibrate && vibration) {
     if (a.phase === 'TIMER') {
       nav.vibrate(VIBRATION_LONG_MS);
     } else {

--- a/app/actions/Quest.tsx
+++ b/app/actions/Quest.tsx
@@ -1,9 +1,10 @@
 import Redux from 'redux'
 import {
+  remoteify,
   QuestNodeAction,
   ViewQuestAction
 } from './ActionTypes'
-import {SettingsType} from '../reducers/StateTypes'
+import {AppState, SettingsType} from '../reducers/StateTypes'
 import {toCard} from './Card'
 import {QuestDetails} from '../reducers/QuestTypes'
 import {initCardTemplate, ParserNode} from '../cardtemplates/Template'
@@ -15,11 +16,19 @@ export function initQuest(details: QuestDetails, questNode: Cheerio, ctx: Templa
   return {type: 'QUEST_NODE', node, details};
 }
 
-export function choice(settings: SettingsType, node: ParserNode, index: number) {
-  return (dispatch: Redux.Dispatch<any>): any => {
-    dispatch(loadNode(settings, node.handleAction(index)));
-  }
+interface ChoiceArgs {
+  settings?: SettingsType;
+  node?: ParserNode;
+  index: number;
 }
+export const choice = remoteify(function choice(a: ChoiceArgs, dispatch: Redux.Dispatch<any>, getState: ()=>AppState): ChoiceArgs {
+  if (!a.node || !a.settings) {
+    a.node = getState().quest.node;
+    a.settings = getState().settings;
+  }
+  dispatch(loadNode(a.settings, a.node.handleAction(a.index)));
+  return {index: a.index};
+});
 
 export function event(node: ParserNode, evt: string) {
   return (dispatch: Redux.Dispatch<any>): any => {

--- a/app/actions/Quest.tsx
+++ b/app/actions/Quest.tsx
@@ -4,7 +4,7 @@ import {
   QuestNodeAction,
   ViewQuestAction
 } from './ActionTypes'
-import {AppState, SettingsType} from '../reducers/StateTypes'
+import {AppStateWithHistory, SettingsType} from '../reducers/StateTypes'
 import {toCard} from './Card'
 import {QuestDetails} from '../reducers/QuestTypes'
 import {initCardTemplate, ParserNode} from '../cardtemplates/Template'
@@ -21,7 +21,7 @@ interface ChoiceArgs {
   node?: ParserNode;
   index: number;
 }
-export const choice = remoteify(function choice(a: ChoiceArgs, dispatch: Redux.Dispatch<any>, getState: ()=>AppState): ChoiceArgs {
+export const choice = remoteify(function choice(a: ChoiceArgs, dispatch: Redux.Dispatch<any>, getState: ()=>AppStateWithHistory): ChoiceArgs {
   if (!a.node || !a.settings) {
     a.node = getState().quest.node;
     a.settings = getState().settings;
@@ -30,11 +30,17 @@ export const choice = remoteify(function choice(a: ChoiceArgs, dispatch: Redux.D
   return {index: a.index};
 });
 
-export function event(node: ParserNode, evt: string) {
-  return (dispatch: Redux.Dispatch<any>): any => {
-    dispatch(loadNode(null, node.handleAction(evt)));
-  }
+interface EventArgs {
+  node?: ParserNode;
+  evt: string;
 }
+export const event = remoteify(function event(a: EventArgs, dispatch: Redux.Dispatch<any>, getState: ()=>AppStateWithHistory): EventArgs {
+  if (!a.node) {
+    a.node = getState().quest.node;
+  }
+  dispatch(loadNode(null, a.node.handleAction(a.evt)));
+  return {evt: a.evt};
+});
 
 // used externally by the quest creator, but not by other external App code
 export function loadNode(settings: SettingsType, node: ParserNode) {

--- a/app/actions/RemotePlay.tsx
+++ b/app/actions/RemotePlay.tsx
@@ -1,17 +1,16 @@
+import React from 'react'
 import Redux from 'redux'
 import {toCard} from './Card'
 import {remotePlaySettings} from '../Constants'
-import {RemotePlayAction, NavigateAction, ReturnAction, getRemoteAction} from './ActionTypes'
+import {LocalAction, NavigateAction, ReturnAction, getRemoteAction} from './ActionTypes'
 import {UserState} from '../reducers/StateTypes'
 import {logEvent} from '../Main'
 import {openSnackbar} from '../actions/Snackbar'
 import {RemotePlayEvent} from 'expedition-qdl/lib/remote/Events'
 import {getRemotePlayClient} from '../RemotePlay'
 
-export function local(a: Redux.Action): RemotePlayAction {
-  // We return a 'remote play' action here as it's not re-broadcast by
-  // remote play middleware.
-  return {type: 'REMOTE_PLAY_ACTION', action: a};
+export function local(a: Redux.Action): LocalAction {
+  return {type: 'LOCAL', action: a};
 }
 
 export function handleRemotePlayEvent(e: RemotePlayEvent) {
@@ -28,8 +27,10 @@ export function handleRemotePlayEvent(e: RemotePlayEvent) {
         if (!a) {
           console.log('Received unknown remote action ' + e.event.name);
         } else {
-          console.log('Dispatching remote action ' + e.event.name);
-          dispatch(local(a(JSON.parse(e.event.args))));
+          console.log('Inbound: ' + e.event.name + '(' + e.event.args + ')');
+          // Note: This is still dispatched locally; it's called as a
+          // secondary dispatch.
+          dispatch(a(JSON.parse(e.event.args)));
         }
         break;
       case 'ERROR':

--- a/app/actions/Web.tsx
+++ b/app/actions/Web.tsx
@@ -32,17 +32,17 @@ export function fetchLocal(url: string, callback: Function) {
   request.send();
 }
 
-export function fetchQuestXML(details: QuestDetails) {
-  return (dispatch: Redux.Dispatch<any>): any => {
-    fetchLocal(details.publishedurl, (err: Error, result: string) => {
-      if (err) {
-        return dispatch(openSnackbar('Network error: Please check your connection.'));
-      }
-      const questNode = cheerio.load(result)('quest');
-      dispatch(loadQuestXML({details, questNode, ctx: defaultContext()}));
-    });
-  };
-}
+export const fetchQuestXML = remoteify(function fetchQuestXML(details: QuestDetails, dispatch: Redux.Dispatch<any>) {
+  fetchLocal(details.publishedurl, (err: Error, result: string) => {
+    if (err) {
+      return dispatch(openSnackbar('Network error: Please check your connection.'));
+    }
+    const questNode = cheerio.load(result)('quest');
+    dispatch(loadQuestXML({details, questNode, ctx: defaultContext()}));
+  });
+
+  return details;
+});
 
 // for loading quests in the app - Quest Creator injects directly into initQuest
 function loadQuestXML(a: {details: QuestDetails, questNode: Cheerio, ctx: TemplateContext}) {
@@ -61,6 +61,7 @@ function loadQuestXML(a: {details: QuestDetails, questNode: Cheerio, ctx: Templa
     } else {
       dispatch(toCard({name: 'QUEST_START'}));
     }
+
     return {...a, questNode: (null as Cheerio)};
   }
 }

--- a/app/cardtemplates/Template.tsx
+++ b/app/cardtemplates/Template.tsx
@@ -21,7 +21,7 @@ export function initCardTemplate(node: ParserNode, settings: SettingsType) {
       case 'roleplay':
         return dispatch(initRoleplay(node, settings));
       case 'combat':
-        return dispatch(initCombat(node, settings));
+        return dispatch(initCombat({node, settings}));
       default:
         throw new Error('Unsupported node type ' + node.getTag());
     }

--- a/app/cardtemplates/combat/Actions.test.tsx
+++ b/app/cardtemplates/combat/Actions.test.tsx
@@ -24,11 +24,7 @@ const TEST_SETTINGS = {
 const TEST_NODE = new ParserNode(cheerio.load('<combat><e>Test</e><e>Lich</e><e>lich</e><event on="win"></event><event on="lose"></event></combat>')('combat'), defaultContext());
 
 describe('Combat actions', () => {
-  let baseNode: ParserNode = null;
-  {
-    const actions = Action(initCombat as any).execute({node: TEST_NODE.clone(), settings: TEST_SETTINGS});
-    baseNode = actions[actions.length-1].node;
-  }
+  const baseNode = Action(initCombat as any).execute({node: TEST_NODE.clone(), settings: TEST_SETTINGS})[1].node;;
 
   const newCombatNode = () => {
     return baseNode.clone();
@@ -38,7 +34,7 @@ describe('Combat actions', () => {
     const actions = Action(initCombat as any).execute({node: TEST_NODE.clone(), settings: TEST_SETTINGS});
 
     it('triggers nav to combat start', () => {
-      expect(actions[1]).toEqual(jasmine.objectContaining({
+      expect(actions[2]).toEqual(jasmine.objectContaining({
         type: 'NAVIGATE',
         to: jasmine.objectContaining({
           name: 'QUEST_CARD',
@@ -50,7 +46,7 @@ describe('Combat actions', () => {
     it('parses initial state', () => {
       // "Unknown" enemies are given tier 1.
       // Known enemies' tier is parsed from constants.
-      expect(actions[2].node.ctx.templates.combat).toEqual(jasmine.objectContaining({
+      expect(actions[1].node.ctx.templates.combat).toEqual(jasmine.objectContaining({
         custom: false,
         roundCount: 0,
         tier: 9,
@@ -66,16 +62,16 @@ describe('Combat actions', () => {
   });
 
   describe('initCustomCombat', () => {
-    const actions = Action(initCustomCombat as any).execute(TEST_SETTINGS);
+    const actions = Action(initCustomCombat as any).execute({settings: TEST_SETTINGS});
 
     it('has custom=true', () => {
-      expect(actions[2].node.ctx.templates.combat).toEqual(jasmine.objectContaining({
+      expect(actions[1].node.ctx.templates.combat).toEqual(jasmine.objectContaining({
         custom: true
       }));
     });
 
     it('identifies as a combat element', () => {
-      expect(actions[2].node.getTag()).toEqual('combat');
+      expect(actions[1].node.getTag()).toEqual('combat');
     });
   });
 
@@ -249,7 +245,7 @@ describe('Combat actions', () => {
         </event>
         <event on="lose"></event>
       </combat>`)('combat'), defaultContext());
-      node = Action(initCombat as any).execute({node: node.clone(), settings: TEST_SETTINGS})[2].node;
+      node = Action(initCombat as any).execute({node: node.clone(), settings: TEST_SETTINGS})[1].node;
       const actions = Action(handleResolvePhase).execute({node});
       expect(actions[0].node.ctx.templates.combat.roleplay.elem.text()).toEqual('expected');
       expect(actions[2].to.phase).toEqual('ROLEPLAY');
@@ -277,8 +273,7 @@ describe('Combat actions', () => {
       <roleplay id="outside">Outside Roleplay</roleplay>
     </quest>`)('#c1'), defaultContext());
     {
-      let actions = Action(initCombat as any).execute({node: baseNode, settings: TEST_SETTINGS});
-      baseNode = actions[2].node;
+      baseNode = Action(initCombat as any).execute({node: baseNode, settings: TEST_SETTINGS})[1].node;
       baseNode = Action(handleResolvePhase).execute({node: baseNode})[0].node;
     }
 

--- a/app/cardtemplates/combat/Actions.tsx
+++ b/app/cardtemplates/combat/Actions.tsx
@@ -2,7 +2,7 @@ import Redux from 'redux'
 import {PLAYER_DAMAGE_MULT} from '../../Constants'
 import {Enemy, Loot} from '../../reducers/QuestTypes'
 import {CombatDifficultySettings, CombatAttack} from './Types'
-import {DifficultyType, SettingsType} from '../../reducers/StateTypes'
+import {DifficultyType, SettingsType, AppStateWithHistory} from '../../reducers/StateTypes'
 import {ParserNode, defaultContext} from '../Template'
 import {toCard} from '../../actions/Card'
 import {COMBAT_DIFFICULTY, PLAYER_TIME_MULT} from '../../Constants'
@@ -37,18 +37,23 @@ export function initCombat(a: InitCombatArgs) {
       roundTimeMillis: a.settings.timerSeconds * 1000 * (PLAYER_TIME_MULT[a.settings.numPlayers] || 1),
       ...getDifficultySettings(a.settings.difficulty),
     };
-    dispatch(toCard({name: 'QUEST_CARD', phase: 'DRAW_ENEMIES'}));
+    dispatch({type: 'PUSH_HISTORY'});
     dispatch({type: 'QUEST_NODE', node: a.node} as QuestNodeAction);
+    dispatch(toCard({name: 'QUEST_CARD', phase: 'DRAW_ENEMIES', noHistory: true}));
   };
 }
 
-export function initCustomCombat(settings: SettingsType) {
-  return initCombat({
-    node: new ParserNode(cheerio.load('<combat></combat>')('combat'), defaultContext()),
-    settings,
-    custom: true
-  });
+interface InitCustomCombatArgs {
+  settings?: SettingsType;
 }
+export const initCustomCombat = remoteify(function initCustomCombat(a: InitCustomCombatArgs, dispatch: Redux.Dispatch<any>): InitCustomCombatArgs {
+  dispatch(initCombat({
+    node: new ParserNode(cheerio.load('<combat></combat>')('combat'), defaultContext()),
+    settings: a.settings,
+    custom: true
+  }));
+  return {};
+});
 
 function getDifficultySettings(difficulty: DifficultyType): CombatDifficultySettings {
   const result = COMBAT_DIFFICULTY[difficulty];
@@ -213,103 +218,132 @@ export function isSurgeNextRound(node: ParserNode): boolean {
   return isSurgeRound(rounds + 1, surgePd);
 }
 
-export function handleResolvePhase(node: ParserNode) {
+interface HandleResolvePhaseArgs {
+  node?: ParserNode;
+}
+export const handleResolvePhase = remoteify(function handleResolvePhase(a: HandleResolvePhaseArgs, dispatch: Redux.Dispatch<any>, getState: () => AppStateWithHistory): HandleResolvePhaseArgs {
+  if (!a.node) {
+    a.node = getState().quest.node;
+  }
+
   // Handles resolution, with a hook for if a <choice on="round"/> tag is specified.
   // Note that handling new combat nodes within a "round" handler has undefined
   // behavior and should be prevented when compiled.
-  return (dispatch: Redux.Dispatch<any>): any => {
-    node = node.clone();
-    if (node.getVisibleKeys().indexOf('round') !== -1) {
-      node.ctx.templates.combat.roleplay = node.getNext('round');
-      // Set node *before* navigation to prevent a blank first roleplay card.
-      dispatch({type: 'QUEST_NODE', node: node} as QuestNodeAction);
-      dispatch(toCard({name: 'QUEST_CARD', phase: 'ROLEPLAY', overrideDebounce: true}));
-    } else {
-      dispatch(toCard({name: 'QUEST_CARD', phase: 'RESOLVE_ABILITIES', overrideDebounce: true}));
-      dispatch({type: 'QUEST_NODE', node: node} as QuestNodeAction);
-    }
+  a.node = a.node.clone();
+  if (a.node.getVisibleKeys().indexOf('round') !== -1) {
+    a.node.ctx.templates.combat.roleplay = a.node.getNext('round');
+    // Set node *before* navigation to prevent a blank first roleplay card.
+    dispatch({type: 'QUEST_NODE', node: a.node} as QuestNodeAction);
+    dispatch(toCard({name: 'QUEST_CARD', phase: 'ROLEPLAY', overrideDebounce: true}));
+  } else {
+    dispatch(toCard({name: 'QUEST_CARD', phase: 'RESOLVE_ABILITIES', overrideDebounce: true}));
+    dispatch({type: 'QUEST_NODE', node: a.node} as QuestNodeAction);
   }
+  return {};
+});
+
+interface MidCombatChoiceArgs {
+  settings?: SettingsType;
+  parent?: ParserNode;
+  index: number;
 }
+export const midCombatChoice = remoteify(function midCombatChoice(a: MidCombatChoiceArgs, dispatch: Redux.Dispatch<any>, getState: () => AppStateWithHistory): MidCombatChoiceArgs {
+  if (!a.parent || !a.settings) {
+    a.parent = getState().quest.node;
+    a.settings = getState().settings;
+  }
+  const remoteArgs: MidCombatChoiceArgs = {index: a.index};
 
-export function midCombatChoice(settings: SettingsType, parent: ParserNode, index: number) {
-  return (dispatch: Redux.Dispatch<any>): any => {
-    parent = parent.clone();
-    const node = parent.ctx.templates.combat.roleplay;
-    const next = node.getNext(index);
-    const nextNode = node.handleAction(index);
-    // Check if the next node is inside a combat node. Bad things will happen if you try to nest combat.
-    let ptr = nextNode && nextNode.elem;
-    while (ptr !== null && ptr.length > 0 && ptr.get(0).tagName.toLowerCase() !== 'combat') {
-      ptr = ptr.parent();
-    }
-    const nextIsTrigger = (next && next.getTag() === 'trigger');
-    const nextIsInCombat = (nextNode && ptr && ptr.length > 0);
+  a.parent = a.parent.clone();
+  const node = a.parent.ctx.templates.combat.roleplay;
+  const next = node.getNext(a.index);
+  const nextNode = node.handleAction(a.index);
+  // Check if the next node is inside a combat node. Bad things will happen if you try to nest combat.
+  let ptr = nextNode && nextNode.elem;
+  while (ptr !== null && ptr.length > 0 && ptr.get(0).tagName.toLowerCase() !== 'combat') {
+    ptr = ptr.parent();
+  }
+  const nextIsTrigger = (next && next.getTag() === 'trigger');
+  const nextIsInCombat = (nextNode && ptr && ptr.length > 0);
 
-    // Check for and resolve triggers
-    if (nextIsTrigger) {
-      const triggerName = next.elem.text().trim().toLowerCase();
+  // Check for and resolve triggers
+  if (nextIsTrigger) {
+    const triggerName = next.elem.text().trim().toLowerCase();
 
-      if (triggerName.startsWith('goto')) {
-        if (!nextIsInCombat) { // Break out of combat
-          return dispatch(loadNode(null, nextNode));
-        }
-        // If in combat, fall through and handle like a normal combat RP node
-      } else {
-        if (next.isEnd()) {
-          return dispatch(toCard({name: 'QUEST_END'}));
-        }
+    if (triggerName.startsWith('goto')) {
+      if (!nextIsInCombat) { // Break out of combat
+        dispatch(loadNode(null, nextNode));
+        return remoteArgs;
+      }
+      // If in combat, fall through and handle like a normal combat RP node
+    } else {
+      if (next.isEnd()) {
+        dispatch(toCard({name: 'QUEST_END'}));
+        return remoteArgs;
+      }
 
-        // If the trigger exits via the win/lose handlers, break out of combat
-        const parentCondition = nextNode.elem.parent().attr('on');
-        if (parentCondition === 'win' || parentCondition === 'lose') {
-          return dispatch(loadNode(settings, nextNode));
-        }
+      // If the trigger exits via the win/lose handlers, break out of combat
+      const parentCondition = nextNode.elem.parent().attr('on');
+      if (parentCondition === 'win' || parentCondition === 'lose') {
+        dispatch(loadNode(a.settings, nextNode));
+        return remoteArgs;
       }
     }
+  }
 
-    if (!nextIsInCombat) {
-      // Ignore this as invalid and proceed to the resolution phase
-      parent.ctx.templates.combat.roleplay = null;
-      dispatch(toCard({name: 'QUEST_CARD', phase: 'RESOLVE_ABILITIES', overrideDebounce: true}));
-    } else {
-      // Continue in-combat roleplay
-      parent.ctx.templates.combat.roleplay = nextNode;
-      dispatch(toCard({name: 'QUEST_CARD', phase: 'ROLEPLAY', overrideDebounce: true}));
-    }
-    dispatch({type: 'QUEST_NODE', node: parent} as QuestNodeAction);
-  };
+  if (!nextIsInCombat) {
+    // Ignore this as invalid and proceed to the resolution phase
+    a.parent.ctx.templates.combat.roleplay = null;
+    dispatch(toCard({name: 'QUEST_CARD', phase: 'RESOLVE_ABILITIES', overrideDebounce: true}));
+  } else {
+    // Continue in-combat roleplay
+    a.parent.ctx.templates.combat.roleplay = nextNode;
+    dispatch(toCard({name: 'QUEST_CARD', phase: 'ROLEPLAY', overrideDebounce: true}));
+  }
+  dispatch({type: 'QUEST_NODE', node: a.parent} as QuestNodeAction);
+
+  return remoteArgs;
+});
+
+interface HandleCombatTimerStopArgs {
+  node?: ParserNode;
+  settings?: SettingsType;
+  elapsedMillis: number;
 }
+export const handleCombatTimerStop = remoteify(function handleCombatTimerStop(a: HandleCombatTimerStopArgs, dispatch: Redux.Dispatch<any>, getState: () => AppStateWithHistory): HandleCombatTimerStopArgs {
+  if (!a.node || !a.settings) {
+    a.node = getState().quest.node;
+    a.settings = getState().settings;
+  }
 
-export function handleCombatTimerStop(node: ParserNode, settings: SettingsType, elapsedMillis: number) {
-  return (dispatch: Redux.Dispatch<any>): any => {
-    node = node.clone();
-    node.ctx.templates.combat.mostRecentAttack = generateCombatAttack(node, settings, elapsedMillis);
-    node.ctx.templates.combat.mostRecentRolls = generateRolls(settings.numPlayers);
-    node.ctx.templates.combat.roundCount++;
+  a.node = a.node.clone();
+  a.node.ctx.templates.combat.mostRecentAttack = generateCombatAttack(a.node, a.settings, a.elapsedMillis);
+  a.node.ctx.templates.combat.mostRecentRolls = generateRolls(a.settings.numPlayers);
+  a.node.ctx.templates.combat.roundCount++;
 
-    if (node.ctx.templates.combat.mostRecentAttack.surge) {
-      // Since we always skip the previous card (the timer) when going back,
-      // We can preset the quest node here. This populates context in a way that
-      // the latest round is considered when the "on round" branch is evaluated.
-      dispatch({type: 'QUEST_NODE', node: node} as QuestNodeAction);
-      dispatch(toCard({name: 'QUEST_CARD', phase: 'SURGE', overrideDebounce: true}));
+  if (a.node.ctx.templates.combat.mostRecentAttack.surge) {
+    // Since we always skip the previous card (the timer) when going back,
+    // We can preset the quest node here. This populates context in a way that
+    // the latest round is considered when the "on round" branch is evaluated.
+    dispatch({type: 'QUEST_NODE', node: a.node} as QuestNodeAction);
+    dispatch(toCard({name: 'QUEST_CARD', phase: 'SURGE', overrideDebounce: true}));
+  } else {
+    dispatch(handleResolvePhase({node: a.node}));
+  }
 
-    } else {
-      dispatch(handleResolvePhase(node));
-    }
-  };
-}
+  return {elapsedMillis: a.elapsedMillis};
+});
 
 interface HandleCombatEndArgs {
   node?: ParserNode;
-  serializedNode?: ParserNode;
   settings: SettingsType;
   victory: boolean;
   maxTier: number;
 }
-export const handleCombatEnd = remoteify(function handleCombatEnd(a: HandleCombatEndArgs, dispatch: Redux.Dispatch<any>) {
-  if (a.serializedNode) {
-    console.error('Unimplemented: remote play combat end deserialization');
+export const handleCombatEnd = remoteify(function handleCombatEnd(a: HandleCombatEndArgs, dispatch: Redux.Dispatch<any>, getState: () => AppStateWithHistory) {
+  if (!a.node || !a.settings) {
+    a.node = getState().quest.node;
+    a.settings = getState().settings;
   }
 
   // Edit the final card before cloning
@@ -325,18 +359,42 @@ export const handleCombatEnd = remoteify(function handleCombatEnd(a: HandleComba
   dispatch(toCard({name: 'QUEST_CARD', phase: (a.victory) ? 'VICTORY' : 'DEFEAT',  overrideDebounce: true}));
   dispatch({type: 'QUEST_NODE', node: a.node} as QuestNodeAction);
 
-  return {...a, serializedNode: a.node.getComparisonKey(), node: null};
+  return {victory: a.victory, maxTier: a.maxTier};
 });
 
-export function tierSumDelta(node: ParserNode, current: number, delta: number): QuestNodeAction {
-  node = node.clone();
-  node.ctx.templates.combat.tier = Math.max(current + delta, 0);
-  return {type: 'QUEST_NODE', node};
+interface TierSumDeltaArgs {
+  node?: ParserNode;
+  current: number;
+  delta: number;
 }
+export const tierSumDelta = remoteify(function tierSumDelta(a: TierSumDeltaArgs, dispatch: Redux.Dispatch<any>, getState: () => AppStateWithHistory): TierSumDeltaArgs {
+  if (!a.node) {
+    a.node = getState().quest.node;
+  }
 
-export function adventurerDelta(node: ParserNode, settings: SettingsType, current: number, delta: number): QuestNodeAction {
-  const newAdventurerCount = Math.min(Math.max(0, current + delta), settings.numPlayers);
-  node = node.clone();
-  node.ctx.templates.combat.numAliveAdventurers = newAdventurerCount;
-  return {type: 'QUEST_NODE', node};
+  a.node = a.node.clone();
+  a.node.ctx.templates.combat.tier = Math.max(a.current + a.delta, 0);
+  dispatch({type: 'QUEST_NODE', node: a.node});
+
+  return {current: a.current, delta: a.delta};
+});
+
+interface AdventurerDeltaArgs {
+  node?: ParserNode;
+  settings?: SettingsType;
+  current: number;
+  delta: number;
 }
+export const adventurerDelta = remoteify(function adventurerDelta(a: AdventurerDeltaArgs, dispatch: Redux.Dispatch<any>, getState: () => AppStateWithHistory): AdventurerDeltaArgs {
+  if (!a.node || !a.settings) {
+    a.node = getState().quest.node;
+    a.settings = getState().settings;
+  }
+
+  const newAdventurerCount = Math.min(Math.max(0, a.current + a.delta), a.settings.numPlayers);
+  a.node = a.node.clone();
+  a.node.ctx.templates.combat.numAliveAdventurers = newAdventurerCount;
+  dispatch({type: 'QUEST_NODE', node: a.node});
+
+  return {current: a.current, delta: a.delta};
+});

--- a/app/cardtemplates/combat/CombatContainer.tsx
+++ b/app/cardtemplates/combat/CombatContainer.tsx
@@ -94,7 +94,7 @@ const mapDispatchToProps = (dispatch: Redux.Dispatch<any>, ownProps: any): Comba
     },
     onReturn: () => {postTimerReturn(dispatch)},
     onEvent: (node: ParserNode, evt: string) => {
-      dispatch(event(node, evt));
+      dispatch(event({node, evt}));
     },
     onTierSumDelta: (node: ParserNode, current: number, delta: number) => {
       dispatch(tierSumDelta(node, current, delta));

--- a/app/cardtemplates/combat/CombatContainer.tsx
+++ b/app/cardtemplates/combat/CombatContainer.tsx
@@ -87,26 +87,26 @@ const mapDispatchToProps = (dispatch: Redux.Dispatch<any>, ownProps: any): Comba
       dispatch(handleCombatEnd({node, settings, victory: false, maxTier}));
     },
     onTimerStop: (node: ParserNode, settings: SettingsType, elapsedMillis: number, surge: boolean) => {
-      dispatch(handleCombatTimerStop(node, settings, elapsedMillis));
+      dispatch(handleCombatTimerStop({node, settings, elapsedMillis}));
     },
     onSurgeNext: (node: ParserNode) => {
-      dispatch(handleResolvePhase(node));
+      dispatch(handleResolvePhase({node}));
     },
     onReturn: () => {postTimerReturn(dispatch)},
     onEvent: (node: ParserNode, evt: string) => {
       dispatch(event({node, evt}));
     },
     onTierSumDelta: (node: ParserNode, current: number, delta: number) => {
-      dispatch(tierSumDelta(node, current, delta));
+      dispatch(tierSumDelta({node, current, delta}));
     },
     onAdventurerDelta: (node: ParserNode, settings: SettingsType, current: number, delta: number) => {
-      dispatch(adventurerDelta(node, settings, current, delta));
+      dispatch(adventurerDelta({node, settings, current, delta}));
     },
     onCustomEnd: () => {
       dispatch(toPrevious({name: 'QUEST_CARD', phase: 'DRAW_ENEMIES', before: false}));
     },
     onChoice: (settings: SettingsType, parent: ParserNode, index: number) => {
-      dispatch(midCombatChoice(settings, parent, index));
+      dispatch(midCombatChoice({settings, parent, index}));
     },
   };
 }

--- a/app/cardtemplates/roleplay/Actions.tsx
+++ b/app/cardtemplates/roleplay/Actions.tsx
@@ -6,11 +6,12 @@ import {QuestNodeAction} from '../../actions/ActionTypes'
 
 export function initRoleplay(node: ParserNode, settings: SettingsType, custom?: boolean) {
   return (dispatch: Redux.Dispatch<any>): any => {
-    // We set the quest state *after* the toCard() dispatch to prevent
+    // We set the quest state *after* updating the history to prevent
     // the history from grabbing the quest state before navigating.
     // This bug manifests as toPrevious() sliding back to the same card
     // content.
-    dispatch(toCard({name: 'QUEST_CARD'}));
+    dispatch({type: 'PUSH_HISTORY'});
     dispatch({type: 'QUEST_NODE', node} as QuestNodeAction);
+    dispatch(toCard({name: 'QUEST_CARD', noHistory: true}));
   };
 }

--- a/app/cardtemplates/roleplay/RoleplayContainer.tsx
+++ b/app/cardtemplates/roleplay/RoleplayContainer.tsx
@@ -21,7 +21,7 @@ const mapStateToProps = (state: AppStateWithHistory, ownProps: RoleplayStateProp
 const mapDispatchToProps = (dispatch: Redux.Dispatch<any>, ownProps: any): RoleplayDispatchProps => {
   return {
     onChoice: (settings: SettingsType, node: ParserNode, index: number) => {
-      dispatch(choice(settings, node, index));
+      dispatch(choice({settings, node, index}));
     },
     onRetry: () => {
       dispatch(toPrevious({name: 'QUEST_CARD', phase: 'DRAW_ENEMIES', before: true}));

--- a/app/components/ToolsContainer.test.tsx
+++ b/app/components/ToolsContainer.test.tsx
@@ -1,21 +1,13 @@
 import {initialSettings} from '../reducers/Settings'
 import {mapDispatchToProps} from './ToolsContainer'
-import configureStore  from 'redux-mock-store'
-import {RemotePlayClient} from '../RemotePlay'
+import {newMockStore} from '../Testing'
 
 describe('ToolsContainer', () => {
-  let client: any;
-  let mockStore: any;
-  beforeEach(() => {
-    client = new RemotePlayClient();
-    mockStore = (initialState: any) => {return configureStore([client.createActionMiddleware()])(initialState)};
-  });
-
   it('dispatches custom combat on callback', () => {
-    const store = mockStore({});
+    const store = newMockStore({});
     mapDispatchToProps(store.dispatch, null).onCustomCombatSelect(initialSettings);
     // TODO: Simplify/remove.
-    expect(store.getActions()[1]).toEqual(jasmine.objectContaining({
+    expect(store.getActions()[2]).toEqual(jasmine.objectContaining({
       type: 'NAVIGATE',
       to: jasmine.objectContaining({name:'QUEST_CARD', phase: 'DRAW_ENEMIES'}),
     }));

--- a/app/components/ToolsContainer.test.tsx
+++ b/app/components/ToolsContainer.test.tsx
@@ -15,7 +15,7 @@ describe('ToolsContainer', () => {
     const store = mockStore({});
     mapDispatchToProps(store.dispatch, null).onCustomCombatSelect(initialSettings);
     // TODO: Simplify/remove.
-    expect(store.getActions()[0]).toEqual(jasmine.objectContaining({
+    expect(store.getActions()[1]).toEqual(jasmine.objectContaining({
       type: 'NAVIGATE',
       to: jasmine.objectContaining({name:'QUEST_CARD', phase: 'DRAW_ENEMIES'}),
     }));

--- a/app/components/ToolsContainer.tsx
+++ b/app/components/ToolsContainer.tsx
@@ -23,7 +23,7 @@ const mapStateToProps = (state: AppState, ownProps: ToolsStateProps): ToolsState
 export const mapDispatchToProps = (dispatch: Redux.Dispatch<any>, ownProps: any): ToolsDispatchProps => {
   return {
     onCustomCombatSelect(settings: SettingsType): void {
-      dispatch(initCustomCombat(settings));
+      dispatch(initCustomCombat({settings}));
     },
     onQuestCreatorSelect(): void {
       window.open(URLS.questCreator, '_system');

--- a/app/components/base/TimerCard.tsx
+++ b/app/components/base/TimerCard.tsx
@@ -35,6 +35,14 @@ export default class TimerCard extends React.Component<TimerCardProps, {}> {
     }
   }
 
+  componentWillUnmount() {
+    // Remote play may unmount this component without a touch event.
+    // This makes sure our timer eventually stops.
+    if (this.interval) {
+      clearInterval(this.interval);
+    }
+  }
+
   render() {
     const timeRemainingSec = this.state.timeRemaining / 1000;
     let formattedTimer: string;

--- a/app/reducers/Card.tsx
+++ b/app/reducers/Card.tsx
@@ -8,7 +8,6 @@ const historyApi = (typeof history.pushState !== 'undefined');
 // ts: 0 solves an obscure bug (instead of Date.now()) where rapidly triggering navigations with undefined states
 // (specifically from the editor) wouldn't work b/c their ts diffs were < DEBOUNCE
 export function card(state: CardState = {name: 'SPLASH_CARD', ts: 0}, action: Redux.Action): CardState {
-  console.log(action);
   switch (action.type) {
     case 'NAVIGATE':
       const navigateAction = (action as NavigateAction);

--- a/app/reducers/CombinedReducers.tsx
+++ b/app/reducers/CombinedReducers.tsx
@@ -84,8 +84,8 @@ export default function combinedReducerWithHistory(state: AppStateWithHistory, a
     // Create a new array (objects may be shared)
     history = state._history.slice();
 
-    if (action.type === 'NAVIGATE') {
-      // Save a copy of existing state to _history whenever we go to a new card
+    if (action.type === 'PUSH_HISTORY') {
+      // Save a copy of existing state to _history
       history.push({...state, _history: undefined, _return: undefined, settings: undefined} as AppState);
     }
   }


### PR DESCRIPTION
Required splitting logic for saving state to history away from card navigation :(

On the bright side, "when stuff saves" is much more explicit now and can be done arbitrarily.

This also solidifies behavior of the remote play wrapper around actions - the invocation of the `remotify`'d action is pushed to remote clients, but *all* actions dispatched as a result of the invocation remain local. Any actions not wrapped in `remotify` are treated as local.