### PR TITLE
Uppercase remote play session secret

### DIFF
--- a/app/components/RemotePlayContainer.tsx
+++ b/app/components/RemotePlayContainer.tsx
@@ -22,7 +22,7 @@ const mapDispatchToProps = (dispatch: Redux.Dispatch<any>, ownProps: any): Remot
       if (secret.length !== 4) {
         return dispatch(openSnackbar('Please enter the full session code (4 characters)'));
       }
-      return dispatch(remotePlayConnect(user, secret));
+      return dispatch(remotePlayConnect(user, secret.toUpperCase()));
     },
     onReconnect: (user: UserState, id: SessionID) => {
       console.log('TODO RECONNECT ' + id);


### PR DESCRIPTION
Moving to `window.prompt` took away auto-uppercasing of entry text; this converts the entries to uppercase before sending them.

https://github.com/ExpeditionRPG/expedition-app/issues/446