### PR TITLE
RemotePlay bugfixes

### DIFF
--- a/app/actions/ActionTypes.tsx
+++ b/app/actions/ActionTypes.tsx
@@ -169,6 +169,9 @@ export function remoteify<A>(a: (args: A, dispatch?: Redux.Dispatch<any>, getSta
   const remoted = (args: A) => {
     return ([a.name, a, args] as any) as Redux.Action; // We know better >:}
   }
+  if (REMOTE_ACTIONS[a.name]) {
+    console.error('ERROR: Remote action ' + a.name + ' already registered elsewhere! This will break remote play!');
+  }
   REMOTE_ACTIONS[a.name] = remoted;
   return remoted;
 }

--- a/app/actions/RemotePlay.tsx
+++ b/app/actions/RemotePlay.tsx
@@ -46,9 +46,15 @@ export function handleRemotePlayEvent(e: RemotePlayEvent) {
           console.log('Received unknown remote action ' + e.event.name);
         } else {
           console.log('Inbound: ' + e.event.name + '(' + e.event.args + ')');
+
+          // Set a "remote" inflight marker so it's identifiable
+          // when debugging.
+          const action = a(JSON.parse(e.event.args));
+          (action as any)._inflight = 'remote';
+
           // Note: This is still dispatched locally; it's called as a
           // secondary dispatch.
-          dispatch(a(JSON.parse(e.event.args)));
+          dispatch(action);
         }
         break;
       case 'ERROR':

--- a/app/cardtemplates/combat/Actions.test.tsx
+++ b/app/cardtemplates/combat/Actions.test.tsx
@@ -24,7 +24,7 @@ const TEST_SETTINGS = {
 const TEST_NODE = new ParserNode(cheerio.load('<combat><e>Test</e><e>Lich</e><e>lich</e><event on="win"></event><event on="lose"></event></combat>')('combat'), defaultContext());
 
 describe('Combat actions', () => {
-  const baseNode = Action(initCombat as any).execute({node: TEST_NODE.clone(), settings: TEST_SETTINGS})[1].node;;
+  const baseNode = Action(initCombat as any).execute({node: TEST_NODE.clone(), settings: TEST_SETTINGS})[1].node;
 
   const newCombatNode = () => {
     return baseNode.clone();
@@ -302,9 +302,9 @@ describe('Combat actions', () => {
 
     it('goes to next round when pnode.getNext() falls outside of combat scope', () => {
       const node = newCombatNode();
-      const rp2 = Action(midCombatChoice).execute({settings: TEST_SETTINGS, node: node, index: 3, maxTier: 0, seed: ''})[2].node;
+      const rp2 = Action(midCombatChoice).execute({settings: TEST_SETTINGS, node: node, index: 3, maxTier: 0, seed: ''})[1].node;
       const actions = Action(midCombatChoice).execute({settings: TEST_SETTINGS, node: rp2, index: 0, maxTier: 0, seed: ''});
-      expect(actions[1].to.phase).toEqual('RESOLVE_ABILITIES');
+      expect(actions[2].to.phase).toEqual('RESOLVE_ABILITIES');
     });
 
     it('handles gotos that point to outside of combat', () => {
@@ -315,13 +315,13 @@ describe('Combat actions', () => {
 
     it('handles GOTOs that point to other roleplaying inside of the same combat', () => {
       const actions = Action(midCombatChoice).execute({settings: TEST_SETTINGS, node: newCombatNode(), index: 5, maxTier: 0, seed: ''});
-      expect(actions[1].to.phase).toEqual('MID_COMBAT_ROLEPLAY');
-      expect(actions[2].node.elem.text()).toEqual('rp2');
+      expect(actions[2].to.phase).toEqual('MID_COMBAT_ROLEPLAY');
+      expect(actions[1].node.elem.text()).toEqual('rp2');
     });
 
     it('renders as combat for RPs inside of same combat', () => {
       const actions = Action(midCombatChoice).execute({settings: TEST_SETTINGS, node: newCombatNode(), index: 3, maxTier: 0, seed: ''});
-      expect(actions[1].to.phase).toEqual('MID_COMBAT_ROLEPLAY');
+      expect(actions[2].to.phase).toEqual('MID_COMBAT_ROLEPLAY');
     });
   });
 

--- a/app/cardtemplates/combat/Actions.tsx
+++ b/app/cardtemplates/combat/Actions.tsx
@@ -456,7 +456,7 @@ export const midCombatChoice = remoteify(function midCombatChoice(a: MidCombatCh
     // interestitial roleplay. Go back to combat resolution phase.
     dispatch({type: 'PUSH_HISTORY'});
     dispatch({type: 'QUEST_NODE', node: new ParserNode(parentCombatElem, a.node.ctx)} as QuestNodeAction);
-    dispatch(toCard({name: 'QUEST_CARD', phase: 'RESOLVE_ABILITIES', overrideDebounce: true}));
+    dispatch(toCard({name: 'QUEST_CARD', phase: 'RESOLVE_ABILITIES', overrideDebounce: true, noHistory: true}));
   }
   return remoteArgs;
 });

--- a/app/cardtemplates/combat/Actions.tsx
+++ b/app/cardtemplates/combat/Actions.tsx
@@ -448,13 +448,15 @@ export const midCombatChoice = remoteify(function midCombatChoice(a: MidCombatCh
 
   if (nextIsInSameCombat) {
     // Continue in-combat roleplay with the next node.
-    dispatch(toCard({name: 'QUEST_CARD', phase: 'MID_COMBAT_ROLEPLAY', overrideDebounce: true}));
+    dispatch({type: 'PUSH_HISTORY'});
     dispatch({type: 'QUEST_NODE', node: nextNode} as QuestNodeAction);
+    dispatch(toCard({name: 'QUEST_CARD', phase: 'MID_COMBAT_ROLEPLAY', overrideDebounce: true, noHistory: true}));
   } else {
     // If the next node is out of this combat, that means we've dropped off the end of the
     // interestitial roleplay. Go back to combat resolution phase.
-    dispatch(toCard({name: 'QUEST_CARD', phase: 'RESOLVE_ABILITIES', overrideDebounce: true}));
+    dispatch({type: 'PUSH_HISTORY'});
     dispatch({type: 'QUEST_NODE', node: new ParserNode(parentCombatElem, a.node.ctx)} as QuestNodeAction);
+    dispatch(toCard({name: 'QUEST_CARD', phase: 'RESOLVE_ABILITIES', overrideDebounce: true}));
   }
   return remoteArgs;
 });

--- a/app/cardtemplates/roleplay/Roleplay.tsx
+++ b/app/cardtemplates/roleplay/Roleplay.tsx
@@ -79,7 +79,10 @@ export function loadRoleplayNode(node: ParserNode): RoleplayResult {
     }
 
     if (tag === 'event') {
-      throw new Error('<roleplay> cannot contain <event>.');
+      // This sometimes triggers on the boundaries between roleplay and combat.
+      // TODO(scott): Find a more principled solution for these errors.
+      console.warn('Warning: <roleplay> cannot contain <event>.');
+      return;
     }
 
     const element: RoleplayElement = {

--- a/app/components/RemotePlayContainer.tsx
+++ b/app/components/RemotePlayContainer.tsx
@@ -22,7 +22,7 @@ const mapDispatchToProps = (dispatch: Redux.Dispatch<any>, ownProps: any): Remot
       if (secret.length !== 4) {
         return dispatch(openSnackbar('Please enter the full session code (4 characters)'));
       }
-      return dispatch(remotePlayConnect(user, secret));
+      return dispatch(remotePlayConnect(user, secret.toUpperCase()));
     },
     onReconnect: (user: UserState, id: SessionID) => {
       console.log('TODO RECONNECT ' + id);

--- a/app/components/base/AppContainer.tsx
+++ b/app/components/base/AppContainer.tsx
@@ -74,12 +74,8 @@ export default class Main extends React.Component<MainProps, {}> {
       };
     }
 
-    if (state.remotePlay && state.remotePlay !== this.state.remotePlay) {
-      // We only prevent card transition when we're not
-      // transitioning away from a remote play "syncing" state.
-      if (state.remotePlay.syncing || !this.state.remotePlay.syncing) {
-        return {...this.state, remotePlay: state.remotePlay};
-      }
+    if (state.remotePlay && state.remotePlay.syncing) {
+      return {...this.state, remotePlay: state.remotePlay};
     }
 
     if (state.snackbar.open !== this.state.snackbar.open) {

--- a/app/reducers/InFlight.test.tsx
+++ b/app/reducers/InFlight.test.tsx
@@ -67,7 +67,9 @@ describe('InFlight reducer', () => {
         stateWithInflight,
         {type: 'INFLIGHT_COMMIT', id: 'action1'} as InflightCommitAction, increment),
         {type: 'INFLIGHT_COMPACT'}, increment);
-      expect(newState._committed).toEqual(jasmine.objectContaining({user: {id: 'a'}} as AppStateWithHistory));
+
+      // The new state should reflect the committed/compacted action.
+      expect(newState).toEqual(jasmine.objectContaining({user: {id: 'a'}} as AppStateWithHistory));
 
       // All other inflight actions are discarded
       expect(newState._inflight).toEqual([]);


### PR DESCRIPTION
#446

- Display error if we ever happen to collide remotified functions names
- Mark remote-triggered actions so they're more identifiable in e.g. redux devtools
- On combat RP interstitial, properly push history before assigning new quest node & navigating when making a choice.
- Some fixes to keep the inflight queue & committed state better synced with redux state.