### PR TITLE
Add remote play stats dialog and analytics instrumentation

### DIFF
--- a/app/Main.test.tsx
+++ b/app/Main.test.tsx
@@ -3,7 +3,7 @@ import {AppStateWithHistory} from './reducers/StateTypes'
 import {init} from './Main'
 import {installStore} from './Store'
 import {setDocument, setWindow} from './Globals'
-import {newMockStore} from './Testing'
+import {newMockStoreWithInitializedState} from './Testing'
 
 function dummyDOM(): Document {
   const doc = document.implementation.createHTMLDocument('testdoc');
@@ -47,10 +47,7 @@ describe('React', () => {
     describe('deviceready event', () => {
       it('triggers silent login'); // Holding off on testing this one until we propagate window state better.
       it('adds backbutton listener', () => {
-        const fakeStore = newMockStore({
-          snackbar: {open: false},
-          settings: {audioEnabled: false}
-        });
+        const fakeStore = newMockStoreWithInitializedState();
         installStore(fakeStore as any as Redux.Store<AppStateWithHistory>);
         const doc = dummyDOM();
         (window as any).plugins = {
@@ -64,8 +61,9 @@ describe('React', () => {
         init();
 
         doc.dispatchEvent(new CustomEvent('deviceready'));
-        doc.dispatchEvent(new CustomEvent('backbutton'));
+        fakeStore.clearActions();
 
+        doc.dispatchEvent(new CustomEvent('backbutton'));
         const actions = fakeStore.getActions();
         expect(actions.length).toEqual(1);
         // Action 0 is expansion select dialog

--- a/app/Style.scss
+++ b/app/Style.scss
@@ -1171,6 +1171,9 @@ span.line {
     & > div {
       background: url(images/papyrus-tiled.jpg) !important;
     }
+    button {
+      padding: 0px 10px !important;
+    }
   }
 
   .centralMessage {

--- a/app/Testing.tsx
+++ b/app/Testing.tsx
@@ -3,6 +3,11 @@ import * as ReduxMockStore from 'redux-mock-store'
 import configureStore from 'redux-mock-store'
 import {RemotePlayClient} from './RemotePlay'
 import {AppState, AppStateWithHistory} from './reducers/StateTypes'
+import combinedReducers from './reducers/CombinedReducers'
+
+export function newMockStoreWithInitializedState() {
+  return newMockStore(combinedReducers({} as any, {type: '@@INIT'}));
+}
 
 export function newMockStore(state: object) {
   const client = new RemotePlayClient();

--- a/app/actions/Web.tsx
+++ b/app/actions/Web.tsx
@@ -16,6 +16,7 @@ import {TemplateContext, ParserNode} from '../cardtemplates/TemplateTypes'
 import {defaultContext} from '../cardtemplates/Template'
 import {remoteify} from './ActionTypes'
 import {MIN_FEEDBACK_LENGTH} from '../Constants'
+import {RemotePlayCounters} from '../RemotePlay'
 
 declare var window:any;
 declare var require:any;
@@ -178,4 +179,32 @@ function postUserFeedback(type: string, data: any) {
         dispatch(openSnackbar('Error submitting review: ' + error));
       });
   };
+}
+
+export function logRemotePlayStats(user: UserState, quest: QuestDetails, stats: RemotePlayCounters): Promise<Response> {
+  try {
+    const state = getStore().getState();
+    const data = {
+      questid: quest.id,
+      questversion: quest.questversion,
+      userid: user.id,
+      platform: getDevicePlatform(),
+      version: getAppVersion(),
+      email: user.email,
+      name: user.name,
+      stats: stats,
+    };
+
+    return fetch(authSettings.urlBase + '/analytics/remoteplay/stats', {
+        method: 'POST',
+        body: JSON.stringify(data),
+      })
+      .then(handleFetchErrors)
+      .catch((error: Error) => {
+        logEvent('analytics_quest_err', { label: error });
+      });
+  } catch(e) {
+    console.error('Failed to log remote play stats');
+    return Promise.resolve(new Response(''));
+  }
 }

--- a/app/actions/Web.tsx
+++ b/app/actions/Web.tsx
@@ -192,7 +192,7 @@ export function logRemotePlayStats(user: UserState, quest: QuestDetails, stats: 
       version: getAppVersion(),
       email: user.email,
       name: user.name,
-      stats: stats,
+      data: stats,
     };
 
     return fetch(authSettings.urlBase + '/analytics/remoteplay/stats', {

--- a/app/components/base/Dialogs.tsx
+++ b/app/components/base/Dialogs.tsx
@@ -3,8 +3,9 @@ import Dialog from 'material-ui/Dialog'
 import FlatButton from 'material-ui/FlatButton'
 import RaisedButton from 'material-ui/RaisedButton'
 import TextField from 'material-ui/TextField'
-
+import {RemotePlayCounters} from '../../RemotePlay'
 import {ContentSetsType, DialogIDType, DialogState, QuestState, SettingsType, UserState, UserFeedbackState} from '../../reducers/StateTypes'
+import {QuestDetails} from '../../reducers/QuestTypes'
 
 interface ExitQuestDialogProps extends React.Props<any> {
   open: boolean;
@@ -49,6 +50,45 @@ export class ExitRemotePlayDialog extends React.Component<ExitRemotePlayDialogPr
         ]}
       >
         <p>Tapping exit will disconnect you from your peers and return you to the home screen.</p>
+      </Dialog>
+    );
+  }
+}
+
+interface RemotePlayStatusDialogProps extends React.Props<any> {
+  open: boolean;
+  stats: RemotePlayCounters;
+  user: UserState;
+  questDetails: QuestDetails;
+  onSendReport: (user: UserState, quest: QuestDetails, stats: RemotePlayCounters) => void;
+  onRequestClose: () => void;
+}
+
+export class RemotePlayStatusDialog extends React.Component<RemotePlayStatusDialogProps, {}> {
+  render(): JSX.Element {
+
+    const stats = <ul>{
+        Object.keys(this.props.stats).map((k) => {
+          return <li>{k}: {this.props.stats[k]}</li>
+        })
+      }</ul>;
+
+    return (
+      <Dialog
+        title="Remote Play Stats"
+        modal={true}
+        contentClassName="dialog"
+        open={Boolean(this.props.open)}
+        actions={[<FlatButton onTouchTap={() => this.props.onRequestClose()}>Cancel</FlatButton>,
+          <FlatButton className="primary" onTouchTap={() => this.props.onSendReport(this.props.user, this.props.questDetails, this.props.stats)}>Send Report</FlatButton>
+        ]}
+      >
+        <p>Here's some remote play debugging information:</p>
+        {stats}
+        <p>
+          If you're experiencing problems with remote play, please
+          tap "Send Report" below to send a log to the Expedition team. Thanks!
+        </p>
       </Dialog>
     );
   }
@@ -214,6 +254,7 @@ export interface DialogsStateProps {
   settings: SettingsType;
   user: UserState;
   userFeedback: UserFeedbackState;
+  remotePlayStats: RemotePlayCounters;
 };
 
 export interface DialogsDispatchProps {
@@ -224,6 +265,7 @@ export interface DialogsDispatchProps {
   onFeedbackSubmit: (quest: QuestState, settings: SettingsType, user: UserState, userFeedback: UserFeedbackState) => void;
   onReportErrorSubmit: (error: string, quest: QuestState, settings: SettingsType, user: UserState, userFeedback: UserFeedbackState) => void;
   onReportQuestSubmit: (quest: QuestState, settings: SettingsType, user: UserState, userFeedback: UserFeedbackState) => void;
+  onSendRemotePlayReport: (user: UserState, quest: QuestDetails, stats: RemotePlayCounters) => void;
   onRequestClose: () => void;
 }
 
@@ -244,6 +286,14 @@ const Dialogs = (props: DialogsProps): JSX.Element => {
       <ExitRemotePlayDialog
         open={props.dialog && props.dialog.open === 'EXIT_REMOTE_PLAY'}
         onExitRemotePlay={props.onExitRemotePlay}
+        onRequestClose={props.onRequestClose}
+      />
+      <RemotePlayStatusDialog
+        open={props.dialog && props.dialog.open === 'REMOTE_PLAY_STATUS'}
+        stats={props.remotePlayStats}
+        user={props.user}
+        questDetails={props.quest.details}
+        onSendReport={props.onSendRemotePlayReport}
         onRequestClose={props.onRequestClose}
       />
       <FeedbackDialog

--- a/app/components/base/DialogsContainer.tsx
+++ b/app/components/base/DialogsContainer.tsx
@@ -4,19 +4,30 @@ import {connect} from 'react-redux'
 import Dialogs, {DialogsStateProps, DialogsDispatchProps} from './Dialogs'
 import {toPrevious} from '../../actions/Card'
 import {setDialog} from '../../actions/Dialog'
+import {openSnackbar} from '../../actions/Snackbar'
 import {changeSettings} from '../../actions/Settings'
 import {remotePlayDisconnect} from '../../actions/RemotePlay'
 import {userFeedbackChange} from '../../actions/UserFeedback'
-import {submitUserFeedback} from '../../actions/Web'
+import {submitUserFeedback, logRemotePlayStats} from '../../actions/Web'
 import {MIN_FEEDBACK_LENGTH} from '../../Constants'
+import {getRemotePlayClient, RemotePlayCounters, initialRemotePlayCounters} from '../../RemotePlay'
 import {AppState, ContentSetsType, DialogIDType, DialogState, SettingsType, QuestState, UserState, UserFeedbackState} from '../../reducers/StateTypes'
+import {QuestDetails} from '../../reducers/QuestTypes'
 
 const mapStateToProps = (state: AppState, ownProps: any): DialogsStateProps => {
+  let remotePlayStats: RemotePlayCounters;
+  if (state.dialog.open === 'REMOTE_PLAY_STATUS') {
+    remotePlayStats = getRemotePlayClient().getStats();
+  } else {
+    remotePlayStats = initialRemotePlayCounters;
+  }
+
   return {
     dialog: state.dialog,
     quest: state.quest,
     settings: state.settings,
     user: state.user,
+    remotePlayStats,
     userFeedback: state.userFeedback || {} as any,
   };
 }
@@ -31,6 +42,13 @@ const mapDispatchToProps = (dispatch: Redux.Dispatch<any>, ownProps: any): Dialo
       dispatch(remotePlayDisconnect());
       dispatch(setDialog(null));
       dispatch(toPrevious({name: 'SPLASH_CARD', before: false}));
+    },
+    onSendRemotePlayReport: (user: UserState, quest: QuestDetails, stats: RemotePlayCounters) => {
+      logRemotePlayStats(user, quest, stats)
+        .then((r: Response) => {
+          dispatch(openSnackbar('Stats submitted. Thank you!'));
+          dispatch(setDialog(null));
+        })
     },
     onExpansionSelect: (contentSets: ContentSetsType) => {
       dispatch(setDialog(null));

--- a/app/components/base/remote/RemoteFooter.tsx
+++ b/app/components/base/remote/RemoteFooter.tsx
@@ -13,6 +13,7 @@ export interface RemoteFooterStateProps {
 
 export interface RemoteFooterDispatchProps {
   onRemotePlayExit: () => void;
+  onRemotePlayStatusIconTap: () => void;
 }
 
 export interface RemoteFooterProps extends RemoteFooterStateProps, RemoteFooterDispatchProps {
@@ -34,7 +35,7 @@ const RemoteFooter = (props: RemoteFooterProps): JSX.Element => {
   }
 
   // TODO: Indicate when waiting for other user action
-  const statusIcon = (<FlatButton icon={
+  const statusIcon = (<FlatButton onTouchTap={(e: any) => {props.onRemotePlayStatusIconTap();}} icon={
     (rpClient.isConnected()) ? <NetworkWifi color={color} /> : <SignalWifiOff color={color} />
   }/>);
 

--- a/app/components/base/remote/RemoteFooterContainer.tsx
+++ b/app/components/base/remote/RemoteFooterContainer.tsx
@@ -14,6 +14,9 @@ const mapDispatchToProps = (dispatch: Redux.Dispatch<any>, ownProps: any): Remot
   return {
     onRemotePlayExit: () => {
       dispatch(setDialog('EXIT_REMOTE_PLAY'));
+    },
+    onRemotePlayStatusIconTap: () => {
+      dispatch(setDialog('REMOTE_PLAY_STATUS'));
     }
   };
 }

--- a/app/reducers/StateTypes.tsx
+++ b/app/reducers/StateTypes.tsx
@@ -29,7 +29,7 @@ export interface CheckoutState {
   stripe: stripe.Stripe|null;
 }
 
-export type DialogIDType = null | 'EXIT_QUEST' | 'EXPANSION_SELECT' | 'EXIT_REMOTE_PLAY' | 'FEEDBACK' | 'REPORT_ERROR' | 'REPORT_QUEST';
+export type DialogIDType = null | 'EXIT_QUEST' | 'EXPANSION_SELECT' | 'EXIT_REMOTE_PLAY' | 'FEEDBACK' | 'REPORT_ERROR' | 'REPORT_QUEST' | 'REMOTE_PLAY_STATUS';
 export interface DialogState {
   open: DialogIDType;
   message?: string;


### PR DESCRIPTION
For #446

This'll give us a bit more detail on how far into remote play people get before they run into problems, plus some idea on what kind of problems they're facing. 

I'd like to follow on with additional instrumentation that collects and ships off all the recent errors (e.g. the last 50 or so) that the app has thrown, but figured that'd be better to do in a separate PR.