### PR TITLE
Official icon and wording added. #714

### DIFF
--- a/app/Style.scss
+++ b/app/Style.scss
@@ -586,7 +586,6 @@ span.line {
     margin-left: fontsize(flavor)/8;
     margin-right: -(fontsize(flavor)/8);
   }
-
   .starContainer {
     .stars {
       display: flex;
@@ -934,7 +933,6 @@ span.line {
   // ===============================================
   // Card-specific styles
   // ===============================================
-
   .splashScreen {
     width: 100%;
     height: 100%;
@@ -1192,7 +1190,12 @@ span.line {
         height: fontsize(interactive) !important;
         width: fontsize(interactive) !important;
       }
+
     }
+  }
+  .indicator_spacer{
+    position:relative;
+    top: -(size(tiny));
   }
   .questButtonWithIcon {
     .inline_icon {
@@ -1470,4 +1473,3 @@ $fontsizemap: (
   0% { transform: scale(1); }
   100% { transform: scale(0); }
 }
-

--- a/app/components/views/Search.tsx
+++ b/app/components/views/Search.tsx
@@ -4,6 +4,7 @@ import MenuItem from 'material-ui/MenuItem'
 import SelectField from 'material-ui/SelectField'
 import TextField from 'material-ui/TextField'
 import DoneIcon from 'material-ui/svg-icons/action/done'
+import StarsIcon from 'material-ui/svg-icons/action/stars'
 import Button from '../base/Button'
 import Card from '../base/Card'
 import Checkbox from '../base/Checkbox'
@@ -272,7 +273,8 @@ export function renderResult(props: SearchResultProps): JSX.Element {
           {quest.expansionhorror && <img className="inline_icon" src="images/horror_small.svg"></img>}
         </span>
         <div className="indicators">{props.lastPlayed && <DoneIcon className="questPlayedIcon" />}
-          {quest.official !== undefined && quest.official && <img className="inline_icon" src="images/compass_small.svg"/>}
+          {quest.official !== undefined && quest.official && <span className="indicator_spacer"><img className="inline_icon" src="images/compass_small.svg"/></span>}
+          {quest.awarded && <StarsIcon className="starsIcon" />}
         </div>
       </div>
     </Button>
@@ -331,6 +333,7 @@ export function renderDetails(props: SearchDetailsProps): JSX.Element {
         <div className="indicators">
           {props.lastPlayed && <div className="lastPlayed"><DoneIcon className="inline_icon" /> Last played {Moment(props.lastPlayed).fromNow()}</div>}
           {quest.official && <span> <img className="inline_icon" src="images/compass_small.svg"/> Official Quest!</span>}
+            {quest.awarded && <div className="awarded"><StarsIcon className="starsIcon" /> {quest.awarded} </div>}
         </div>
       </div>
       <Button className="bigbutton" onTouchTap={(e)=>props.onPlay(quest, props.isDirectLinked)} remoteID="play">Play</Button>

--- a/app/components/views/Search.tsx
+++ b/app/components/views/Search.tsx
@@ -271,7 +271,9 @@ export function renderResult(props: SearchResultProps): JSX.Element {
         <span className="expansions">
           {quest.expansionhorror && <img className="inline_icon" src="images/horror_small.svg"></img>}
         </span>
-        <div className="indicators">{props.lastPlayed && <DoneIcon className="questPlayedIcon" />}</div>
+        <div className="indicators">{props.lastPlayed && <DoneIcon className="questPlayedIcon" />}
+          {quest.official !== undefined && quest.official && <img className="inline_icon" src="images/compass_small.svg"/>}
+        </div>
       </div>
     </Button>
   );
@@ -328,6 +330,7 @@ export function renderDetails(props: SearchDetailsProps): JSX.Element {
         {(quest.ratingcount && quest.ratingcount >= 1) ? <StarRating readOnly={true} value={+ratingAvg} quantity={quest.ratingcount}/> : ''}
         <div className="indicators">
           {props.lastPlayed && <div className="lastPlayed"><DoneIcon className="inline_icon" /> Last played {Moment(props.lastPlayed).fromNow()}</div>}
+          {quest.official && <span> <img className="inline_icon" src="images/compass_small.svg"/> Official Quest!</span>}
         </div>
       </div>
       <Button className="bigbutton" onTouchTap={(e)=>props.onPlay(quest, props.isDirectLinked)} remoteID="play">Play</Button>


### PR DESCRIPTION
This is the first part of this fix. #714 for the "Official" icon and handling on quest detail and quest search results pages.  I'll follow-on and add the award part when we get an award icon.